### PR TITLE
support input list custom scalar

### DIFF
--- a/rust/shalom_dart_codegen/dart_tests/test/custom_scalar/point.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/custom_scalar/point.dart
@@ -8,6 +8,15 @@ class Point {
 
   @override
   String toString() => 'Point(x: $x, y: $y)';
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is Point && other.x == x && other.y == y);
+  }
+
+  @override
+  int get hashCode => Object.hash(x, y);
 }
 
 class _PointScalarImpl implements CustomScalarImpl<Point> {

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListInsideInputObject.shalom.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListInsideInputObject.shalom.dart
@@ -1,0 +1,214 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion
+
+import "schema.shalom.dart";
+import '../../custom_scalar/point.dart' as rmhlxei;
+
+import 'package:shalom_core/shalom_core.dart';
+
+typedef JsonObject = Map<String, dynamic>;
+
+class InputCustomScalarListInsideInputObjectResponse {
+  /// class members
+
+  final InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject?
+  InputCustomScalarListInsideInputObject;
+
+  // keywordargs constructor
+  InputCustomScalarListInsideInputObjectResponse({
+    this.InputCustomScalarListInsideInputObject,
+  });
+  static InputCustomScalarListInsideInputObjectResponse fromJson(
+    JsonObject data,
+  ) {
+    final InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject?
+    InputCustomScalarListInsideInputObject_value;
+
+    final JsonObject? InputCustomScalarListInsideInputObject$raw =
+        data['InputCustomScalarListInsideInputObject'];
+    if (InputCustomScalarListInsideInputObject$raw != null) {
+      InputCustomScalarListInsideInputObject_value =
+          InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject.fromJson(
+            InputCustomScalarListInsideInputObject$raw,
+          );
+    } else {
+      InputCustomScalarListInsideInputObject_value = null;
+    }
+
+    return InputCustomScalarListInsideInputObjectResponse(
+      InputCustomScalarListInsideInputObject:
+          InputCustomScalarListInsideInputObject_value,
+    );
+  }
+
+  InputCustomScalarListInsideInputObjectResponse updateWithJson(
+    JsonObject data,
+  ) {
+    final InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject?
+    InputCustomScalarListInsideInputObject_value;
+    if (data.containsKey('InputCustomScalarListInsideInputObject')) {
+      final JsonObject? InputCustomScalarListInsideInputObject$raw =
+          data['InputCustomScalarListInsideInputObject'];
+      if (InputCustomScalarListInsideInputObject$raw != null) {
+        InputCustomScalarListInsideInputObject_value =
+            InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject.fromJson(
+              InputCustomScalarListInsideInputObject$raw,
+            );
+      } else {
+        InputCustomScalarListInsideInputObject_value = null;
+      }
+    } else {
+      InputCustomScalarListInsideInputObject_value =
+          InputCustomScalarListInsideInputObject;
+    }
+
+    return InputCustomScalarListInsideInputObjectResponse(
+      InputCustomScalarListInsideInputObject:
+          InputCustomScalarListInsideInputObject_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListInsideInputObjectResponse &&
+            other.InputCustomScalarListInsideInputObject ==
+                InputCustomScalarListInsideInputObject);
+  }
+
+  @override
+  int get hashCode => InputCustomScalarListInsideInputObject.hashCode;
+
+  JsonObject toJson() {
+    return {
+      'InputCustomScalarListInsideInputObject':
+          InputCustomScalarListInsideInputObject?.toJson(),
+    };
+  }
+}
+
+// ------------ OBJECT DEFINITIONS -------------
+
+class InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject {
+  /// class members
+
+  final bool success;
+
+  final String? message;
+
+  // keywordargs constructor
+  InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject({
+    required this.success,
+
+    this.message,
+  });
+  static InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject
+  fromJson(JsonObject data) {
+    final bool success_value;
+
+    success_value = data['success'];
+
+    final String? message_value;
+
+    message_value = data['message'];
+
+    return InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject
+  updateWithJson(JsonObject data) {
+    final bool success_value;
+    if (data.containsKey('success')) {
+      success_value = data['success'];
+    } else {
+      success_value = success;
+    }
+
+    final String? message_value;
+    if (data.containsKey('message')) {
+      message_value = data['message'];
+    } else {
+      message_value = message;
+    }
+
+    return InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other
+                is InputCustomScalarListInsideInputObject_InputCustomScalarListInsideInputObject &&
+            other.success == success &&
+            other.message == message);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([success, message]);
+
+  JsonObject toJson() {
+    return {'success': success, 'message': message};
+  }
+}
+
+// ------------ END OBJECT DEFINITIONS -------------
+
+class RequestInputCustomScalarListInsideInputObject extends Requestable {
+  final InputCustomScalarListInsideInputObjectVariables variables;
+
+  RequestInputCustomScalarListInsideInputObject({required this.variables});
+
+  @override
+  Request toRequest() {
+    JsonObject variablesJson = variables.toJson();
+    return Request(
+      query:
+          r"""mutation InputCustomScalarListInsideInputObject($newContainer: ItemContainerInput!) {
+  InputCustomScalarListInsideInputObject(newContainer: $newContainer) {
+    success
+    message
+  }
+}""",
+      variables: variablesJson,
+      opType: OperationType.Mutation,
+      StringopName: 'InputCustomScalarListInsideInputObject',
+    );
+  }
+}
+
+class InputCustomScalarListInsideInputObjectVariables {
+  final ItemContainerInput newContainer;
+
+  InputCustomScalarListInsideInputObjectVariables({required this.newContainer});
+
+  JsonObject toJson() {
+    JsonObject data = {};
+
+    data["newContainer"] = this.newContainer.toJson();
+
+    return data;
+  }
+
+  InputCustomScalarListInsideInputObjectVariables updateWith({
+    ItemContainerInput? newContainer,
+  }) {
+    final ItemContainerInput newContainer$next;
+
+    if (newContainer != null) {
+      newContainer$next = newContainer;
+    } else {
+      newContainer$next = this.newContainer;
+    }
+
+    return InputCustomScalarListInsideInputObjectVariables(
+      newContainer: newContainer$next,
+    );
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListMaybe.shalom.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListMaybe.shalom.dart
@@ -1,0 +1,206 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion
+
+import "schema.shalom.dart";
+import '../../custom_scalar/point.dart' as rmhlxei;
+
+import 'package:shalom_core/shalom_core.dart';
+
+typedef JsonObject = Map<String, dynamic>;
+
+class InputCustomScalarListMaybeResponse {
+  /// class members
+
+  final InputCustomScalarListMaybe_InputCustomScalarListMaybe?
+  InputCustomScalarListMaybe;
+
+  // keywordargs constructor
+  InputCustomScalarListMaybeResponse({this.InputCustomScalarListMaybe});
+  static InputCustomScalarListMaybeResponse fromJson(JsonObject data) {
+    final InputCustomScalarListMaybe_InputCustomScalarListMaybe?
+    InputCustomScalarListMaybe_value;
+
+    final JsonObject? InputCustomScalarListMaybe$raw =
+        data['InputCustomScalarListMaybe'];
+    if (InputCustomScalarListMaybe$raw != null) {
+      InputCustomScalarListMaybe_value =
+          InputCustomScalarListMaybe_InputCustomScalarListMaybe.fromJson(
+            InputCustomScalarListMaybe$raw,
+          );
+    } else {
+      InputCustomScalarListMaybe_value = null;
+    }
+
+    return InputCustomScalarListMaybeResponse(
+      InputCustomScalarListMaybe: InputCustomScalarListMaybe_value,
+    );
+  }
+
+  InputCustomScalarListMaybeResponse updateWithJson(JsonObject data) {
+    final InputCustomScalarListMaybe_InputCustomScalarListMaybe?
+    InputCustomScalarListMaybe_value;
+    if (data.containsKey('InputCustomScalarListMaybe')) {
+      final JsonObject? InputCustomScalarListMaybe$raw =
+          data['InputCustomScalarListMaybe'];
+      if (InputCustomScalarListMaybe$raw != null) {
+        InputCustomScalarListMaybe_value =
+            InputCustomScalarListMaybe_InputCustomScalarListMaybe.fromJson(
+              InputCustomScalarListMaybe$raw,
+            );
+      } else {
+        InputCustomScalarListMaybe_value = null;
+      }
+    } else {
+      InputCustomScalarListMaybe_value = InputCustomScalarListMaybe;
+    }
+
+    return InputCustomScalarListMaybeResponse(
+      InputCustomScalarListMaybe: InputCustomScalarListMaybe_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListMaybeResponse &&
+            other.InputCustomScalarListMaybe == InputCustomScalarListMaybe);
+  }
+
+  @override
+  int get hashCode => InputCustomScalarListMaybe.hashCode;
+
+  JsonObject toJson() {
+    return {'InputCustomScalarListMaybe': InputCustomScalarListMaybe?.toJson()};
+  }
+}
+
+// ------------ OBJECT DEFINITIONS -------------
+
+class InputCustomScalarListMaybe_InputCustomScalarListMaybe {
+  /// class members
+
+  final bool success;
+
+  final String? message;
+
+  // keywordargs constructor
+  InputCustomScalarListMaybe_InputCustomScalarListMaybe({
+    required this.success,
+
+    this.message,
+  });
+  static InputCustomScalarListMaybe_InputCustomScalarListMaybe fromJson(
+    JsonObject data,
+  ) {
+    final bool success_value;
+
+    success_value = data['success'];
+
+    final String? message_value;
+
+    message_value = data['message'];
+
+    return InputCustomScalarListMaybe_InputCustomScalarListMaybe(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  InputCustomScalarListMaybe_InputCustomScalarListMaybe updateWithJson(
+    JsonObject data,
+  ) {
+    final bool success_value;
+    if (data.containsKey('success')) {
+      success_value = data['success'];
+    } else {
+      success_value = success;
+    }
+
+    final String? message_value;
+    if (data.containsKey('message')) {
+      message_value = data['message'];
+    } else {
+      message_value = message;
+    }
+
+    return InputCustomScalarListMaybe_InputCustomScalarListMaybe(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListMaybe_InputCustomScalarListMaybe &&
+            other.success == success &&
+            other.message == message);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([success, message]);
+
+  JsonObject toJson() {
+    return {'success': success, 'message': message};
+  }
+}
+
+// ------------ END OBJECT DEFINITIONS -------------
+
+class RequestInputCustomScalarListMaybe extends Requestable {
+  final InputCustomScalarListMaybeVariables variables;
+
+  RequestInputCustomScalarListMaybe({required this.variables});
+
+  @override
+  Request toRequest() {
+    JsonObject variablesJson = variables.toJson();
+    return Request(
+      query: r"""mutation InputCustomScalarListMaybe($optionalItems: [Point!]) {
+  InputCustomScalarListMaybe(optionalItems: $optionalItems) {
+    success
+    message
+  }
+}""",
+      variables: variablesJson,
+      opType: OperationType.Mutation,
+      StringopName: 'InputCustomScalarListMaybe',
+    );
+  }
+}
+
+class InputCustomScalarListMaybeVariables {
+  final Option<List<rmhlxei.Point>?> optionalItems;
+
+  InputCustomScalarListMaybeVariables({this.optionalItems = const None()});
+
+  JsonObject toJson() {
+    JsonObject data = {};
+
+    if (optionalItems.isSome()) {
+      final value = this.optionalItems.some();
+      data["optionalItems"] =
+          value?.map((e) => rmhlxei.pointScalarImpl.serialize(e)).toList();
+    }
+
+    return data;
+  }
+
+  InputCustomScalarListMaybeVariables updateWith({
+    Option<Option<List<rmhlxei.Point>?>> optionalItems = const None(),
+  }) {
+    final Option<List<rmhlxei.Point>?> optionalItems$next;
+
+    switch (optionalItems) {
+      case Some(value: final updateData):
+        optionalItems$next = updateData;
+      case None():
+        optionalItems$next = this.optionalItems;
+    }
+
+    return InputCustomScalarListMaybeVariables(
+      optionalItems: optionalItems$next,
+    );
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListNullableMaybe.shalom.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListNullableMaybe.shalom.dart
@@ -1,0 +1,219 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion
+
+import "schema.shalom.dart";
+import '../../custom_scalar/point.dart' as rmhlxei;
+
+import 'package:shalom_core/shalom_core.dart';
+
+typedef JsonObject = Map<String, dynamic>;
+
+class InputCustomScalarListNullableMaybeResponse {
+  /// class members
+
+  final InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe?
+  InputCustomScalarListNullableMaybe;
+
+  // keywordargs constructor
+  InputCustomScalarListNullableMaybeResponse({
+    this.InputCustomScalarListNullableMaybe,
+  });
+  static InputCustomScalarListNullableMaybeResponse fromJson(JsonObject data) {
+    final InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe?
+    InputCustomScalarListNullableMaybe_value;
+
+    final JsonObject? InputCustomScalarListNullableMaybe$raw =
+        data['InputCustomScalarListNullableMaybe'];
+    if (InputCustomScalarListNullableMaybe$raw != null) {
+      InputCustomScalarListNullableMaybe_value =
+          InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe.fromJson(
+            InputCustomScalarListNullableMaybe$raw,
+          );
+    } else {
+      InputCustomScalarListNullableMaybe_value = null;
+    }
+
+    return InputCustomScalarListNullableMaybeResponse(
+      InputCustomScalarListNullableMaybe:
+          InputCustomScalarListNullableMaybe_value,
+    );
+  }
+
+  InputCustomScalarListNullableMaybeResponse updateWithJson(JsonObject data) {
+    final InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe?
+    InputCustomScalarListNullableMaybe_value;
+    if (data.containsKey('InputCustomScalarListNullableMaybe')) {
+      final JsonObject? InputCustomScalarListNullableMaybe$raw =
+          data['InputCustomScalarListNullableMaybe'];
+      if (InputCustomScalarListNullableMaybe$raw != null) {
+        InputCustomScalarListNullableMaybe_value =
+            InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe.fromJson(
+              InputCustomScalarListNullableMaybe$raw,
+            );
+      } else {
+        InputCustomScalarListNullableMaybe_value = null;
+      }
+    } else {
+      InputCustomScalarListNullableMaybe_value =
+          InputCustomScalarListNullableMaybe;
+    }
+
+    return InputCustomScalarListNullableMaybeResponse(
+      InputCustomScalarListNullableMaybe:
+          InputCustomScalarListNullableMaybe_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListNullableMaybeResponse &&
+            other.InputCustomScalarListNullableMaybe ==
+                InputCustomScalarListNullableMaybe);
+  }
+
+  @override
+  int get hashCode => InputCustomScalarListNullableMaybe.hashCode;
+
+  JsonObject toJson() {
+    return {
+      'InputCustomScalarListNullableMaybe':
+          InputCustomScalarListNullableMaybe?.toJson(),
+    };
+  }
+}
+
+// ------------ OBJECT DEFINITIONS -------------
+
+class InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe {
+  /// class members
+
+  final bool success;
+
+  final String? message;
+
+  // keywordargs constructor
+  InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe({
+    required this.success,
+
+    this.message,
+  });
+  static InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe
+  fromJson(JsonObject data) {
+    final bool success_value;
+
+    success_value = data['success'];
+
+    final String? message_value;
+
+    message_value = data['message'];
+
+    return InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe
+  updateWithJson(JsonObject data) {
+    final bool success_value;
+    if (data.containsKey('success')) {
+      success_value = data['success'];
+    } else {
+      success_value = success;
+    }
+
+    final String? message_value;
+    if (data.containsKey('message')) {
+      message_value = data['message'];
+    } else {
+      message_value = message;
+    }
+
+    return InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other
+                is InputCustomScalarListNullableMaybe_InputCustomScalarListNullableMaybe &&
+            other.success == success &&
+            other.message == message);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([success, message]);
+
+  JsonObject toJson() {
+    return {'success': success, 'message': message};
+  }
+}
+
+// ------------ END OBJECT DEFINITIONS -------------
+
+class RequestInputCustomScalarListNullableMaybe extends Requestable {
+  final InputCustomScalarListNullableMaybeVariables variables;
+
+  RequestInputCustomScalarListNullableMaybe({required this.variables});
+
+  @override
+  Request toRequest() {
+    JsonObject variablesJson = variables.toJson();
+    return Request(
+      query:
+          r"""mutation InputCustomScalarListNullableMaybe($sparseData: [Point]) {
+  InputCustomScalarListNullableMaybe(sparseData: $sparseData) {
+    success
+    message
+  }
+}""",
+      variables: variablesJson,
+      opType: OperationType.Mutation,
+      StringopName: 'InputCustomScalarListNullableMaybe',
+    );
+  }
+}
+
+class InputCustomScalarListNullableMaybeVariables {
+  final Option<List<rmhlxei.Point?>?> sparseData;
+
+  InputCustomScalarListNullableMaybeVariables({this.sparseData = const None()});
+
+  JsonObject toJson() {
+    JsonObject data = {};
+
+    if (sparseData.isSome()) {
+      final value = this.sparseData.some();
+      data["sparseData"] =
+          value
+              ?.map(
+                (e) => e == null ? null : rmhlxei.pointScalarImpl.serialize(e!),
+              )
+              .toList();
+    }
+
+    return data;
+  }
+
+  InputCustomScalarListNullableMaybeVariables updateWith({
+    Option<Option<List<rmhlxei.Point?>?>> sparseData = const None(),
+  }) {
+    final Option<List<rmhlxei.Point?>?> sparseData$next;
+
+    switch (sparseData) {
+      case Some(value: final updateData):
+        sparseData$next = updateData;
+      case None():
+        sparseData$next = this.sparseData;
+    }
+
+    return InputCustomScalarListNullableMaybeVariables(
+      sparseData: sparseData$next,
+    );
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListOptionalWithDefault.shalom.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListOptionalWithDefault.shalom.dart
@@ -1,0 +1,218 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion
+
+import "schema.shalom.dart";
+import '../../custom_scalar/point.dart' as rmhlxei;
+
+import 'package:shalom_core/shalom_core.dart';
+
+typedef JsonObject = Map<String, dynamic>;
+
+class InputCustomScalarListOptionalWithDefaultResponse {
+  /// class members
+
+  final InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault?
+  InputCustomScalarListOptionalWithDefault;
+
+  // keywordargs constructor
+  InputCustomScalarListOptionalWithDefaultResponse({
+    this.InputCustomScalarListOptionalWithDefault,
+  });
+  static InputCustomScalarListOptionalWithDefaultResponse fromJson(
+    JsonObject data,
+  ) {
+    final InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault?
+    InputCustomScalarListOptionalWithDefault_value;
+
+    final JsonObject? InputCustomScalarListOptionalWithDefault$raw =
+        data['InputCustomScalarListOptionalWithDefault'];
+    if (InputCustomScalarListOptionalWithDefault$raw != null) {
+      InputCustomScalarListOptionalWithDefault_value =
+          InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault.fromJson(
+            InputCustomScalarListOptionalWithDefault$raw,
+          );
+    } else {
+      InputCustomScalarListOptionalWithDefault_value = null;
+    }
+
+    return InputCustomScalarListOptionalWithDefaultResponse(
+      InputCustomScalarListOptionalWithDefault:
+          InputCustomScalarListOptionalWithDefault_value,
+    );
+  }
+
+  InputCustomScalarListOptionalWithDefaultResponse updateWithJson(
+    JsonObject data,
+  ) {
+    final InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault?
+    InputCustomScalarListOptionalWithDefault_value;
+    if (data.containsKey('InputCustomScalarListOptionalWithDefault')) {
+      final JsonObject? InputCustomScalarListOptionalWithDefault$raw =
+          data['InputCustomScalarListOptionalWithDefault'];
+      if (InputCustomScalarListOptionalWithDefault$raw != null) {
+        InputCustomScalarListOptionalWithDefault_value =
+            InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault.fromJson(
+              InputCustomScalarListOptionalWithDefault$raw,
+            );
+      } else {
+        InputCustomScalarListOptionalWithDefault_value = null;
+      }
+    } else {
+      InputCustomScalarListOptionalWithDefault_value =
+          InputCustomScalarListOptionalWithDefault;
+    }
+
+    return InputCustomScalarListOptionalWithDefaultResponse(
+      InputCustomScalarListOptionalWithDefault:
+          InputCustomScalarListOptionalWithDefault_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListOptionalWithDefaultResponse &&
+            other.InputCustomScalarListOptionalWithDefault ==
+                InputCustomScalarListOptionalWithDefault);
+  }
+
+  @override
+  int get hashCode => InputCustomScalarListOptionalWithDefault.hashCode;
+
+  JsonObject toJson() {
+    return {
+      'InputCustomScalarListOptionalWithDefault':
+          InputCustomScalarListOptionalWithDefault?.toJson(),
+    };
+  }
+}
+
+// ------------ OBJECT DEFINITIONS -------------
+
+class InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault {
+  /// class members
+
+  final bool success;
+
+  final String? message;
+
+  // keywordargs constructor
+  InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault({
+    required this.success,
+
+    this.message,
+  });
+  static InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault
+  fromJson(JsonObject data) {
+    final bool success_value;
+
+    success_value = data['success'];
+
+    final String? message_value;
+
+    message_value = data['message'];
+
+    return InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault
+  updateWithJson(JsonObject data) {
+    final bool success_value;
+    if (data.containsKey('success')) {
+      success_value = data['success'];
+    } else {
+      success_value = success;
+    }
+
+    final String? message_value;
+    if (data.containsKey('message')) {
+      message_value = data['message'];
+    } else {
+      message_value = message;
+    }
+
+    return InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other
+                is InputCustomScalarListOptionalWithDefault_InputCustomScalarListOptionalWithDefault &&
+            other.success == success &&
+            other.message == message);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([success, message]);
+
+  JsonObject toJson() {
+    return {'success': success, 'message': message};
+  }
+}
+
+// ------------ END OBJECT DEFINITIONS -------------
+
+class RequestInputCustomScalarListOptionalWithDefault extends Requestable {
+  final InputCustomScalarListOptionalWithDefaultVariables variables;
+
+  RequestInputCustomScalarListOptionalWithDefault({required this.variables});
+
+  @override
+  Request toRequest() {
+    JsonObject variablesJson = variables.toJson();
+    return Request(
+      query:
+          r"""mutation InputCustomScalarListOptionalWithDefault($defaultItems: [Point!] = null) {
+  InputCustomScalarListOptionalWithDefault(defaultItems: $defaultItems) {
+    success
+    message
+  }
+}""",
+      variables: variablesJson,
+      opType: OperationType.Mutation,
+      StringopName: 'InputCustomScalarListOptionalWithDefault',
+    );
+  }
+}
+
+class InputCustomScalarListOptionalWithDefaultVariables {
+  final List<rmhlxei.Point>? defaultItems;
+
+  InputCustomScalarListOptionalWithDefaultVariables({this.defaultItems});
+
+  JsonObject toJson() {
+    JsonObject data = {};
+
+    data["defaultItems"] =
+        this.defaultItems
+            ?.map((e) => rmhlxei.pointScalarImpl.serialize(e))
+            .toList();
+
+    return data;
+  }
+
+  InputCustomScalarListOptionalWithDefaultVariables updateWith({
+    Option<List<rmhlxei.Point>?> defaultItems = const None(),
+  }) {
+    final List<rmhlxei.Point>? defaultItems$next;
+
+    switch (defaultItems) {
+      case Some(value: final updateData):
+        defaultItems$next = updateData;
+      case None():
+        defaultItems$next = this.defaultItems;
+    }
+
+    return InputCustomScalarListOptionalWithDefaultVariables(
+      defaultItems: defaultItems$next,
+    );
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListRequired.shalom.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/InputCustomScalarListRequired.shalom.dart
@@ -1,0 +1,208 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion
+
+import "schema.shalom.dart";
+import '../../custom_scalar/point.dart' as rmhlxei;
+
+import 'package:shalom_core/shalom_core.dart';
+
+typedef JsonObject = Map<String, dynamic>;
+
+class InputCustomScalarListRequiredResponse {
+  /// class members
+
+  final InputCustomScalarListRequired_InputCustomScalarListRequired?
+  InputCustomScalarListRequired;
+
+  // keywordargs constructor
+  InputCustomScalarListRequiredResponse({this.InputCustomScalarListRequired});
+  static InputCustomScalarListRequiredResponse fromJson(JsonObject data) {
+    final InputCustomScalarListRequired_InputCustomScalarListRequired?
+    InputCustomScalarListRequired_value;
+
+    final JsonObject? InputCustomScalarListRequired$raw =
+        data['InputCustomScalarListRequired'];
+    if (InputCustomScalarListRequired$raw != null) {
+      InputCustomScalarListRequired_value =
+          InputCustomScalarListRequired_InputCustomScalarListRequired.fromJson(
+            InputCustomScalarListRequired$raw,
+          );
+    } else {
+      InputCustomScalarListRequired_value = null;
+    }
+
+    return InputCustomScalarListRequiredResponse(
+      InputCustomScalarListRequired: InputCustomScalarListRequired_value,
+    );
+  }
+
+  InputCustomScalarListRequiredResponse updateWithJson(JsonObject data) {
+    final InputCustomScalarListRequired_InputCustomScalarListRequired?
+    InputCustomScalarListRequired_value;
+    if (data.containsKey('InputCustomScalarListRequired')) {
+      final JsonObject? InputCustomScalarListRequired$raw =
+          data['InputCustomScalarListRequired'];
+      if (InputCustomScalarListRequired$raw != null) {
+        InputCustomScalarListRequired_value =
+            InputCustomScalarListRequired_InputCustomScalarListRequired.fromJson(
+              InputCustomScalarListRequired$raw,
+            );
+      } else {
+        InputCustomScalarListRequired_value = null;
+      }
+    } else {
+      InputCustomScalarListRequired_value = InputCustomScalarListRequired;
+    }
+
+    return InputCustomScalarListRequiredResponse(
+      InputCustomScalarListRequired: InputCustomScalarListRequired_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListRequiredResponse &&
+            other.InputCustomScalarListRequired ==
+                InputCustomScalarListRequired);
+  }
+
+  @override
+  int get hashCode => InputCustomScalarListRequired.hashCode;
+
+  JsonObject toJson() {
+    return {
+      'InputCustomScalarListRequired': InputCustomScalarListRequired?.toJson(),
+    };
+  }
+}
+
+// ------------ OBJECT DEFINITIONS -------------
+
+class InputCustomScalarListRequired_InputCustomScalarListRequired {
+  /// class members
+
+  final bool success;
+
+  final String? message;
+
+  // keywordargs constructor
+  InputCustomScalarListRequired_InputCustomScalarListRequired({
+    required this.success,
+
+    this.message,
+  });
+  static InputCustomScalarListRequired_InputCustomScalarListRequired fromJson(
+    JsonObject data,
+  ) {
+    final bool success_value;
+
+    success_value = data['success'];
+
+    final String? message_value;
+
+    message_value = data['message'];
+
+    return InputCustomScalarListRequired_InputCustomScalarListRequired(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  InputCustomScalarListRequired_InputCustomScalarListRequired updateWithJson(
+    JsonObject data,
+  ) {
+    final bool success_value;
+    if (data.containsKey('success')) {
+      success_value = data['success'];
+    } else {
+      success_value = success;
+    }
+
+    final String? message_value;
+    if (data.containsKey('message')) {
+      message_value = data['message'];
+    } else {
+      message_value = message;
+    }
+
+    return InputCustomScalarListRequired_InputCustomScalarListRequired(
+      success: success_value,
+
+      message: message_value,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is InputCustomScalarListRequired_InputCustomScalarListRequired &&
+            other.success == success &&
+            other.message == message);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([success, message]);
+
+  JsonObject toJson() {
+    return {'success': success, 'message': message};
+  }
+}
+
+// ------------ END OBJECT DEFINITIONS -------------
+
+class RequestInputCustomScalarListRequired extends Requestable {
+  final InputCustomScalarListRequiredVariables variables;
+
+  RequestInputCustomScalarListRequired({required this.variables});
+
+  @override
+  Request toRequest() {
+    JsonObject variablesJson = variables.toJson();
+    return Request(
+      query:
+          r"""mutation InputCustomScalarListRequired($requiredItems: [Point!]!) {
+  InputCustomScalarListRequired(requiredItems: $requiredItems) {
+    success
+    message
+  }
+}""",
+      variables: variablesJson,
+      opType: OperationType.Mutation,
+      StringopName: 'InputCustomScalarListRequired',
+    );
+  }
+}
+
+class InputCustomScalarListRequiredVariables {
+  final List<rmhlxei.Point> requiredItems;
+
+  InputCustomScalarListRequiredVariables({required this.requiredItems});
+
+  JsonObject toJson() {
+    JsonObject data = {};
+
+    data["requiredItems"] =
+        this.requiredItems
+            .map((e) => rmhlxei.pointScalarImpl.serialize(e))
+            .toList();
+
+    return data;
+  }
+
+  InputCustomScalarListRequiredVariables updateWith({
+    List<rmhlxei.Point>? requiredItems,
+  }) {
+    final List<rmhlxei.Point> requiredItems$next;
+
+    if (requiredItems != null) {
+      requiredItems$next = requiredItems;
+    } else {
+      requiredItems$next = this.requiredItems;
+    }
+
+    return InputCustomScalarListRequiredVariables(
+      requiredItems: requiredItems$next,
+    );
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/schema.shalom.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/__graphql__/schema.shalom.dart
@@ -1,0 +1,115 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, unnecessary_this, unnecessary_non_null_assertion
+
+import 'package:shalom_core/shalom_core.dart';
+
+import '../../custom_scalar/point.dart' as rmhlxei;
+
+// ------------ Enum DEFINITIONS -------------
+
+// ------------ END Enum DEFINITIONS -------------
+// ------------ Input DEFINITIONS -------------
+
+class ItemContainerInput {
+  final List<rmhlxei.Point?> flexibleItems;
+
+  final String name;
+
+  final Option<List<rmhlxei.Point?>?> optionalItems;
+
+  final List<rmhlxei.Point> requiredItems;
+
+  ItemContainerInput({
+    required this.flexibleItems,
+
+    required this.name,
+
+    this.optionalItems = const None(),
+
+    required this.requiredItems,
+  });
+
+  JsonObject toJson() {
+    JsonObject data = {};
+
+    data["flexibleItems"] =
+        this.flexibleItems
+            .map(
+              (e) => e == null ? null : rmhlxei.pointScalarImpl.serialize(e!),
+            )
+            .toList();
+
+    data["name"] = this.name;
+
+    if (optionalItems.isSome()) {
+      final value = this.optionalItems.some();
+      data["optionalItems"] =
+          value
+              ?.map(
+                (e) => e == null ? null : rmhlxei.pointScalarImpl.serialize(e!),
+              )
+              .toList();
+    }
+
+    data["requiredItems"] =
+        this.requiredItems
+            .map((e) => rmhlxei.pointScalarImpl.serialize(e))
+            .toList();
+
+    return data;
+  }
+
+  ItemContainerInput updateWith({
+    List<rmhlxei.Point?>? flexibleItems,
+
+    String? name,
+
+    Option<Option<List<rmhlxei.Point?>?>> optionalItems = const None(),
+
+    List<rmhlxei.Point>? requiredItems,
+  }) {
+    final List<rmhlxei.Point?> flexibleItems$next;
+
+    if (flexibleItems != null) {
+      flexibleItems$next = flexibleItems;
+    } else {
+      flexibleItems$next = this.flexibleItems;
+    }
+
+    final String name$next;
+
+    if (name != null) {
+      name$next = name;
+    } else {
+      name$next = this.name;
+    }
+
+    final Option<List<rmhlxei.Point?>?> optionalItems$next;
+
+    switch (optionalItems) {
+      case Some(value: final updateData):
+        optionalItems$next = updateData;
+      case None():
+        optionalItems$next = this.optionalItems;
+    }
+
+    final List<rmhlxei.Point> requiredItems$next;
+
+    if (requiredItems != null) {
+      requiredItems$next = requiredItems;
+    } else {
+      requiredItems$next = this.requiredItems;
+    }
+
+    return ItemContainerInput(
+      flexibleItems: flexibleItems$next,
+
+      name: name$next,
+
+      optionalItems: optionalItems$next,
+
+      requiredItems: requiredItems$next,
+    );
+  }
+}
+
+// ------------ END Input DEFINITIONS -------------

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/operations.gql
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/operations.gql
@@ -1,0 +1,34 @@
+mutation InputCustomScalarListRequired($requiredItems: [Point!]!) {
+    InputCustomScalarListRequired(requiredItems: $requiredItems) {
+        success
+        message
+    }
+}
+
+mutation InputCustomScalarListMaybe($optionalItems: [Point!]) {
+    InputCustomScalarListMaybe(optionalItems: $optionalItems) {
+        success
+        message
+    }
+}
+
+mutation InputCustomScalarListNullableMaybe($sparseData: [Point]) {
+    InputCustomScalarListNullableMaybe(sparseData: $sparseData) {
+        success
+        message
+    }
+}
+
+mutation InputCustomScalarListOptionalWithDefault($defaultItems: [Point!] = null) {
+    InputCustomScalarListOptionalWithDefault(defaultItems: $defaultItems) {
+        success
+        message
+    }
+}
+
+mutation InputCustomScalarListInsideInputObject($newContainer: ItemContainerInput!) {
+    InputCustomScalarListInsideInputObject(newContainer: $newContainer) {
+        success
+        message
+    }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/schema.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/schema.graphql
@@ -1,0 +1,43 @@
+scalar Point
+
+type Query {
+    # Output field tests - lists of custom scalars
+    pointListRequired: [Point!]!
+    pointListOptional: [Point!]
+    pointListWithNulls: [Point]!
+    pointListFullyOptional: [Point]
+}
+
+type Mutation {
+    # Input List Use Cases
+
+    # 1. Required List of Required Elements: [Point!]!
+    InputCustomScalarListRequired(requiredItems: [Point!]!): Response
+
+    # 2. Maybe List of Required Elements: [Point!]
+    InputCustomScalarListMaybe(optionalItems: [Point!]): Response
+
+    # 3. Maybe List of Optional Elements: [Point]
+    InputCustomScalarListNullableMaybe(sparseData: [Point]): Response
+
+    # 4. Maybe List of Required Elements with Null Default: [Point!] = null
+    InputCustomScalarListOptionalWithDefault(defaultItems: [Point!] = null): Response
+
+    # 5. Custom Scalar Lists Inside Input Objects
+    InputCustomScalarListInsideInputObject(newContainer: ItemContainerInput!): Response
+}
+
+input ItemContainerInput {
+    name: String!
+    # List of required elements (the list is required, elements are required)
+    requiredItems: [Point!]!
+    # List of optional elements (the list can be null, elements can be null)
+    optionalItems: [Point]
+    # List required, but elements optional (list is required, elements can be null)
+    flexibleItems: [Point]!
+}
+
+type Response {
+    success: Boolean!
+    message: String
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/shalom.yml
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/shalom.yml
@@ -1,0 +1,10 @@
+custom_scalars:
+  Point:
+    graphql_name: "Point"
+    output_type:
+      import_path: "../../custom_scalar/point.dart"
+      symbol_name: "Point"
+
+    impl_symbol:
+      import_path: "../../custom_scalar/point.dart"
+      symbol_name: "pointScalarImpl"

--- a/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/test.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/input_list_custom_scalars/test.dart
@@ -1,0 +1,146 @@
+import 'package:test/test.dart';
+import 'package:shalom_core/shalom_core.dart';
+import '../input_list_custom_scalars/__graphql__/schema.shalom.dart';
+import '__graphql__/InputCustomScalarListRequired.shalom.dart';
+import '__graphql__/InputCustomScalarListMaybe.shalom.dart';
+import '__graphql__/InputCustomScalarListNullableMaybe.shalom.dart';
+import '__graphql__/InputCustomScalarListOptionalWithDefault.shalom.dart';
+import '__graphql__/InputCustomScalarListInsideInputObject.shalom.dart';
+import '../custom_scalar/point.dart';
+
+void main() {
+  final Point point1 = Point(x: 10, y: 20);
+  final Point point2 = Point(x: 30, y: 40);
+  final Point point3 = Point(x: 50, y: 60);
+  final List<Point> samplePoints = [point1, point2, point3];
+
+  group('Input List Custom Scalars', () {
+    test('customScalarListRequired', () {
+      final variables = InputCustomScalarListRequiredVariables(
+        requiredItems: samplePoints,
+      );
+      expect(variables.toJson(), {
+        'requiredItems': ['POINT (10, 20)', 'POINT (30, 40)', 'POINT (50, 60)'],
+      });
+
+      final newVariables = variables.updateWith(
+        requiredItems: [point1, point2],
+      );
+      expect(newVariables.toJson(), {
+        'requiredItems': ['POINT (10, 20)', 'POINT (30, 40)'],
+      });
+
+      expect(newVariables.requiredItems, [point1, point2]);
+      expect(newVariables == variables, false);
+    });
+
+    test('customScalarListMaybe', () {
+      final variables = InputCustomScalarListMaybeVariables(
+        optionalItems: None(),
+      );
+      expect(variables.toJson(), {});
+
+      final someVariables = variables.updateWith(
+        optionalItems: Some(Some(samplePoints)),
+      );
+      expect(someVariables.toJson(), {
+        'optionalItems': ['POINT (10, 20)', 'POINT (30, 40)', 'POINT (50, 60)'],
+      });
+
+      final someWithNullValue = someVariables.updateWith(
+        optionalItems: Some(Some(null)),
+      );
+      expect(someWithNullValue.toJson(), {'optionalItems': null});
+
+      expect(someVariables.optionalItems.some(), samplePoints);
+      expect(someWithNullValue.optionalItems.some(), null);
+    });
+
+    test('customScalarListNullableMaybe', () {
+      final variables = InputCustomScalarListNullableMaybeVariables(
+        sparseData: None(),
+      );
+      expect(variables.toJson(), {});
+
+      final someVariables = variables.updateWith(
+        sparseData: Some(Some([point1, null, point3])),
+      );
+      expect(someVariables.toJson(), {
+        'sparseData': ['POINT (10, 20)', null, 'POINT (50, 60)'],
+      });
+
+      final someWithNullValue = someVariables.updateWith(
+        sparseData: Some(Some(null)),
+      );
+      expect(someWithNullValue.toJson(), {'sparseData': null});
+
+      expect(someVariables.sparseData.some(), [point1, null, point3]);
+      expect(someWithNullValue.sparseData.some(), null);
+    });
+
+    test('customScalarListOptionalWithDefault', () {
+      final variables = InputCustomScalarListOptionalWithDefaultVariables();
+      expect(variables.toJson(), {'defaultItems': null});
+
+      final variablesWithValues = variables.updateWith(
+        defaultItems: Some(samplePoints),
+      );
+      expect(variablesWithValues.toJson(), {
+        'defaultItems': ['POINT (10, 20)', 'POINT (30, 40)', 'POINT (50, 60)'],
+      });
+
+      expect(variablesWithValues.defaultItems, samplePoints);
+    });
+
+    test('customScalarListInsideInputObject', () {
+      final variables = InputCustomScalarListInsideInputObjectVariables(
+        newContainer: ItemContainerInput(
+          name: 'Test Container',
+          requiredItems: [point1, point2],
+          optionalItems: None(),
+          flexibleItems: [point3, null],
+        ),
+      );
+      expect(variables.toJson(), {
+        'newContainer': {
+          'name': 'Test Container',
+          'requiredItems': ['POINT (10, 20)', 'POINT (30, 40)'],
+          'flexibleItems': ['POINT (50, 60)', null],
+        },
+      });
+
+      final updatedVariables = variables.updateWith(
+        newContainer: variables.newContainer.updateWith(
+          name: 'Updated Container',
+          requiredItems: [point1],
+          optionalItems: Some(Some([point2, null, point3])),
+          flexibleItems: [point1, point2, point3],
+        ),
+      );
+      expect(updatedVariables.toJson(), {
+        'newContainer': {
+          'name': 'Updated Container',
+          'requiredItems': ['POINT (10, 20)'],
+          'optionalItems': ['POINT (30, 40)', null, 'POINT (50, 60)'],
+          'flexibleItems': [
+            'POINT (10, 20)',
+            'POINT (30, 40)',
+            'POINT (50, 60)',
+          ],
+        },
+      });
+
+      expect(updatedVariables.newContainer.requiredItems, [point1]);
+      expect(updatedVariables.newContainer.optionalItems.some(), [
+        point2,
+        null,
+        point3,
+      ]);
+      expect(updatedVariables.newContainer.flexibleItems, [
+        point1,
+        point2,
+        point3,
+      ]);
+    });
+  });
+}

--- a/rust/shalom_dart_codegen/tests/usecases_test.rs
+++ b/rust/shalom_dart_codegen/tests/usecases_test.rs
@@ -46,6 +46,11 @@ fn test_input_list_objects_dart() {
 }
 
 #[test]
+fn test_input_list_custom_scalars_dart() {
+    run_dart_tests_for_usecase("input_list_custom_scalars");
+}
+
+#[test]
 fn test_nested_input_objects_dart() {
     run_dart_tests_for_usecase("nested_input_objects");
 }


### PR DESCRIPTION
closes #43

## Summary by Sourcery

Implement support for lists of the custom scalar `Point` in GraphQL inputs by generating Dart code for multiple list configurations, enhance the `Point` Dart class with equality and hashCode overrides, and introduce end-to-end tests in both Dart and Rust to validate the new feature.

New Features:
- Support input lists of custom scalar `Point` in GraphQL input definitions and generate corresponding Dart code for required, optional, nullable, default, and nested scenarios.

Enhancements:
- Override `==` operator and `hashCode` in the Dart `Point` custom scalar class to enable proper equality comparison.

Tests:
- Add a Dart test suite for input list custom scalar use cases and register a Rust test (`test_input_list_custom_scalars_dart`) to execute the new Dart tests.