### PR TITLE
Nir/support list of object

### DIFF
--- a/dart/shalom_core/lib/shalom_core.dart
+++ b/dart/shalom_core/lib/shalom_core.dart
@@ -61,3 +61,13 @@ JsonObject getOrCreateObject(JsonObject onObject, RecordID field) {
     return ret;
   }
 }
+
+extension OptionalAt<T> on List<T>{
+  T? atOpt(int index) {
+      try {
+          return this[index];
+      } on RangeError {
+          return null;
+      }
+  }
+}

--- a/dart/shalom_core/lib/shalom_core.dart
+++ b/dart/shalom_core/lib/shalom_core.dart
@@ -62,8 +62,3 @@ JsonObject getOrCreateObject(JsonObject onObject, RecordID field) {
   }
 }
 
-extension OptionalAt<T> on List<T> {
-  T? atOpt(int index) {
-    return (index >= 0 && index < length) ? this[index] : null;
-  }
-}

--- a/dart/shalom_core/lib/shalom_core.dart
+++ b/dart/shalom_core/lib/shalom_core.dart
@@ -62,8 +62,8 @@ JsonObject getOrCreateObject(JsonObject onObject, RecordID field) {
   }
 }
 
-extension OptionalAt<T> on List<T>{
+extension OptionalAt<T> on List<T> {
   T? atOpt(int index) {
-      return (index >= 0 && index < length) ? this[index] : null;
+    return (index >= 0 && index < length) ? this[index] : null;
   }
 }

--- a/dart/shalom_core/lib/shalom_core.dart
+++ b/dart/shalom_core/lib/shalom_core.dart
@@ -64,10 +64,6 @@ JsonObject getOrCreateObject(JsonObject onObject, RecordID field) {
 
 extension OptionalAt<T> on List<T>{
   T? atOpt(int index) {
-      try {
-          return this[index];
-      } on RangeError {
-          return null;
-      }
+      return (index >= 0 && index < length) ? this[index] : null;
   }
 }

--- a/rust/shalom_core/src/operation/context.rs
+++ b/rust/shalom_core/src/operation/context.rs
@@ -52,6 +52,9 @@ impl OperationContext {
     pub fn get_operation_name(&self) -> &str {
         &self.operation_name
     }
+    pub fn has_variables(&self) -> bool {
+        !self.variables.is_empty()
+    }
 
     pub fn set_root_type(&mut self, root_type: Selection) {
         self.root_type = Some(root_type);

--- a/rust/shalom_core/src/operation/parse.rs
+++ b/rust/shalom_core/src/operation/parse.rs
@@ -363,6 +363,21 @@ where
                 of_type,
                 used_fragments,
             );
+
+            // Register inner object/union selections so they can be found for code generation
+            match &of_kind {
+                SelectionKind::Object(_) | SelectionKind::Union(_) => {
+                    let selection_common = SelectionCommon {
+                        name: path.clone(),
+                        description: None,
+                    };
+                    let inner_selection =
+                        Selection::new(selection_common, of_kind.clone(), Default::default());
+                    ctx.add_selection(path.clone(), inner_selection);
+                }
+                _ => {}
+            }
+
             SelectionKind::new_list(is_optional, of_kind)
         }
     }

--- a/rust/shalom_core/src/operation/parse.rs
+++ b/rust/shalom_core/src/operation/parse.rs
@@ -418,7 +418,7 @@ impl ExecutableContext for OperationContext {
         self.get_selection(&name.to_string())
     }
     fn has_variables(&self) -> bool {
-        return self.has_variables();
+        self.has_variables()
     }
 
     fn get_used_fragments(
@@ -450,7 +450,7 @@ impl ExecutableContext for FragmentContext {
     fn get_selection(&self, name: &str) -> Option<Selection> {
         self.get_selection(&name.to_string())
     }
-    
+
     fn get_used_fragments(
         &self,
         _name: &str,
@@ -464,7 +464,7 @@ impl ExecutableContext for FragmentContext {
     }
 
     fn has_variables(&self) -> bool {
-        return false;
+        false
     }
     fn get_variable(&self, _name: &str) -> Option<&crate::operation::context::OperationVariable> {
         None // Fragments don't have variables

--- a/rust/shalom_core/src/operation/parse.rs
+++ b/rust/shalom_core/src/operation/parse.rs
@@ -408,6 +408,7 @@ pub trait ExecutableContext: Send + Sync + 'static {
 
     fn add_selection(&mut self, name: String, selection: Selection);
     fn get_variable(&self, name: &str) -> Option<&crate::operation::context::OperationVariable>;
+    fn has_variables(&self) -> bool;
     fn add_union_type(&mut self, name: String, union_selection: SharedUnionSelection);
     fn get_union_types(&self) -> &std::collections::HashMap<String, SharedUnionSelection>;
 }
@@ -416,6 +417,10 @@ impl ExecutableContext for OperationContext {
     fn get_selection(&self, name: &str) -> Option<Selection> {
         self.get_selection(&name.to_string())
     }
+    fn has_variables(&self) -> bool {
+        return self.has_variables();
+    }
+
     fn get_used_fragments(
         &self,
         _name: &str,
@@ -445,6 +450,7 @@ impl ExecutableContext for FragmentContext {
     fn get_selection(&self, name: &str) -> Option<Selection> {
         self.get_selection(&name.to_string())
     }
+    
     fn get_used_fragments(
         &self,
         _name: &str,
@@ -457,6 +463,9 @@ impl ExecutableContext for FragmentContext {
         self.add_selection(name, selection)
     }
 
+    fn has_variables(&self) -> bool {
+        return false;
+    }
     fn get_variable(&self, _name: &str) -> Option<&crate::operation::context::OperationVariable> {
         None // Fragments don't have variables
     }

--- a/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/operations.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/operations.graphql
@@ -1,0 +1,30 @@
+query GetUsersRequired {
+  usersRequired {
+    id
+    name
+    email
+    age
+  }
+}
+
+query GetUsersOptional {
+  usersOptional {
+    id
+    name
+    email
+  }
+}
+
+query GetOptionalUsers {
+  optionalUsers {
+    id
+    name
+  }
+}
+
+query GetUsersRequiredPartial {
+  usersRequired {
+    id
+    name
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/schema.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/schema.graphql
@@ -1,0 +1,12 @@
+type Query {
+  usersRequired: [User!]!
+  usersOptional: [User!]
+  optionalUsers: [User]
+}
+
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  age: Int
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/test.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/test.dart
@@ -416,8 +416,8 @@ void main() {
     test('optionalUsers deserialize', () {
       final result = GetOptionalUsersResponse.fromResponse(optionalUsersData);
       expect(result.optionalUsers?.length, 2);
-      expect(result.optionalUsers?[0]?.id, "1");
-      expect(result.optionalUsers?[0]?.name, "Alice");
+      expect(result.optionalUsers?[0].id, "1");
+      expect(result.optionalUsers?[0].name, "Alice");
     });
 
     test('optionalUsers toJson', () {
@@ -462,7 +462,7 @@ void main() {
 
       await hasChanged.future.timeout(Duration(seconds: 1));
       expect(result, equals(nextResult));
-      expect(result.optionalUsers?[0]?.name, "Alice Modified");
+      expect(result.optionalUsers?[0].name, "Alice Modified");
     });
   });
 }

--- a/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/test.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/list_of_objects/test.dart
@@ -1,0 +1,468 @@
+import "dart:async";
+
+import "package:shalom_core/shalom_core.dart";
+import 'package:test/test.dart';
+import "__graphql__/GetUsersRequired.shalom.dart";
+import "__graphql__/GetUsersOptional.shalom.dart";
+import "__graphql__/GetOptionalUsers.shalom.dart";
+import "__graphql__/GetUsersRequiredPartial.shalom.dart";
+
+void main() {
+  final usersRequiredData = {
+    "usersRequired": [
+      {"id": "1", "name": "Alice", "email": "alice@example.com", "age": 30},
+      {"id": "2", "name": "Bob", "email": "bob@example.com", "age": 25},
+      {"id": "3", "name": "Charlie", "email": "charlie@example.com", "age": 35},
+    ],
+  };
+
+  final usersRequiredDataChanged = {
+    "usersRequired": [
+      {
+        "id": "1",
+        "name": "Alice Updated",
+        "email": "alice@example.com",
+        "age": 31
+      },
+      {"id": "2", "name": "Bob", "email": "bob@example.com", "age": 25},
+      {"id": "3", "name": "Charlie", "email": "charlie@example.com", "age": 35},
+    ],
+  };
+
+  final usersRequiredDataLengthChanged = {
+    "usersRequired": [
+      {"id": "1", "name": "Alice", "email": "alice@example.com", "age": 30},
+      {"id": "2", "name": "Bob", "email": "bob@example.com", "age": 25},
+    ],
+  };
+
+  final usersRequiredDataIdChanged = {
+    "usersRequired": [
+      {"id": "1", "name": "Alice", "email": "alice@example.com", "age": 30},
+      {"id": "4", "name": "David", "email": "david@example.com", "age": 28},
+      {"id": "3", "name": "Charlie", "email": "charlie@example.com", "age": 35},
+    ],
+  };
+
+  final usersRequiredEmptyData = {"usersRequired": []};
+
+  group('List of Objects Required', () {
+    test('usersRequired deserialize', () {
+      final result = GetUsersRequiredResponse.fromResponse(usersRequiredData);
+      expect(result.usersRequired.length, 3);
+      expect(result.usersRequired[0].id, "1");
+      expect(result.usersRequired[0].name, "Alice");
+      expect(result.usersRequired[0].email, "alice@example.com");
+      expect(result.usersRequired[0].age, 30);
+      expect(result.usersRequired[1].id, "2");
+      expect(result.usersRequired[1].name, "Bob");
+    });
+
+    test('usersRequired deserialize with empty list', () {
+      final result =
+          GetUsersRequiredResponse.fromResponse(usersRequiredEmptyData);
+      expect(result.usersRequired, []);
+    });
+
+    test('usersRequired toJson', () {
+      final initial = GetUsersRequiredResponse.fromResponse(usersRequiredData);
+      final json = initial.toJson();
+      expect(json, usersRequiredData);
+    });
+
+    test('usersRequired toJson with empty list', () {
+      final initial =
+          GetUsersRequiredResponse.fromResponse(usersRequiredEmptyData);
+      final json = initial.toJson();
+      expect(json, usersRequiredEmptyData);
+    });
+
+    test('usersRequired equals', () {
+      final ctx = ShalomCtx.withCapacity();
+      final result1 =
+          GetUsersRequiredResponse.fromResponse(usersRequiredData, ctx: ctx);
+      final result2 =
+          GetUsersRequiredResponse.fromResponse(usersRequiredData, ctx: ctx);
+      final result3 = GetUsersRequiredResponse.fromResponse(
+          usersRequiredDataChanged,
+          ctx: ctx);
+
+      expect(result1, equals(result2));
+      expect(result1, isNot(equals(result3)));
+    });
+
+    test('usersRequired cacheNormalization - inner field change', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetUsersRequiredResponse.fromResponseImpl(
+        usersRequiredData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersRequiredResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetUsersRequiredResponse.fromResponse(
+        usersRequiredDataChanged,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersRequired[0].name, "Alice Updated");
+      expect(result.usersRequired[0].age, 31);
+    });
+
+    test('usersRequired cacheNormalization - list length changed', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetUsersRequiredResponse.fromResponseImpl(
+        usersRequiredData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersRequiredResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetUsersRequiredResponse.fromResponse(
+        usersRequiredDataLengthChanged,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersRequired.length, 2);
+    });
+
+    test('usersRequired cacheNormalization - object ID changed at index',
+        () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetUsersRequiredResponse.fromResponseImpl(
+        usersRequiredData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersRequiredResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetUsersRequiredResponse.fromResponse(
+        usersRequiredDataIdChanged,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersRequired[1].id, "4");
+      expect(result.usersRequired[1].name, "David");
+    });
+
+    test('usersRequired cacheNormalization - no overlapping deps', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) =
+          GetUsersRequiredPartialResponse.fromResponseImpl(
+        usersRequiredData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersRequiredPartialResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      // Change fields that are not part of the partial query (email, age only)
+      final dataWithOnlyAgeChanged = {
+        "usersRequired": [
+          {
+            "id": "1",
+            "name": "Alice",
+            "email": "alice_updated@example.com",
+            "age": 31
+          },
+          {
+            "id": "2",
+            "name": "Bob",
+            "email": "bob_updated@example.com",
+            "age": 26
+          },
+          {
+            "id": "3",
+            "name": "Charlie",
+            "email": "charlie_updated@example.com",
+            "age": 36
+          },
+        ],
+      };
+
+      final _ = GetUsersRequiredResponse.fromResponse(
+        dataWithOnlyAgeChanged,
+        ctx: ctx,
+      );
+
+      // we don't expect any change as the changed fields (age, email) are not part of the deps
+      await Future.delayed(Duration(milliseconds: 500));
+      expect(hasChanged.isCompleted, false);
+
+      // But name change should trigger update
+      final dataWithNameChange = {
+        "usersRequired": [
+          {
+            "id": "1",
+            "name": "Alice Changed",
+            "email": "alice@example.com",
+            "age": 30
+          },
+          {"id": "2", "name": "Bob", "email": "bob@example.com", "age": 25},
+          {
+            "id": "3",
+            "name": "Charlie",
+            "email": "charlie@example.com",
+            "age": 35
+          },
+        ],
+      };
+
+      final nextResult = GetUsersRequiredPartialResponse.fromResponse(
+        dataWithNameChange,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersRequired[0].name, "Alice Changed");
+    });
+  });
+
+  final usersOptionalData = {
+    "usersOptional": [
+      {"id": "1", "name": "Alice", "email": "alice@example.com"},
+      {"id": "2", "name": "Bob", "email": "bob@example.com"},
+    ],
+  };
+
+  final usersOptionalDataChanged = {
+    "usersOptional": [
+      {"id": "1", "name": "Alice Updated", "email": "alice@example.com"},
+      {"id": "2", "name": "Bob", "email": "bob@example.com"},
+    ],
+  };
+
+  final usersOptionalNullData = {"usersOptional": null};
+  final usersOptionalEmptyData = {"usersOptional": []};
+
+  group('List of Objects Optional', () {
+    test('usersOptional deserialize', () {
+      final result = GetUsersOptionalResponse.fromResponse(usersOptionalData);
+      expect(result.usersOptional?.length, 2);
+      expect(result.usersOptional?[0].id, "1");
+      expect(result.usersOptional?[0].name, "Alice");
+    });
+
+    test('usersOptional deserialize with null', () {
+      final result =
+          GetUsersOptionalResponse.fromResponse(usersOptionalNullData);
+      expect(result.usersOptional, isNull);
+    });
+
+    test('usersOptional deserialize with empty list', () {
+      final result =
+          GetUsersOptionalResponse.fromResponse(usersOptionalEmptyData);
+      expect(result.usersOptional, []);
+    });
+
+    test('usersOptional toJson', () {
+      final initial = GetUsersOptionalResponse.fromResponse(usersOptionalData);
+      final json = initial.toJson();
+      expect(json, usersOptionalData);
+    });
+
+    test('usersOptional toJson with null', () {
+      final initial =
+          GetUsersOptionalResponse.fromResponse(usersOptionalNullData);
+      final json = initial.toJson();
+      expect(json, usersOptionalNullData);
+    });
+
+    test('usersOptional toJson with empty list', () {
+      final initial =
+          GetUsersOptionalResponse.fromResponse(usersOptionalEmptyData);
+      final json = initial.toJson();
+      expect(json, usersOptionalEmptyData);
+    });
+
+    test('usersOptional equals', () {
+      final ctx = ShalomCtx.withCapacity();
+      final result1 =
+          GetUsersOptionalResponse.fromResponse(usersOptionalData, ctx: ctx);
+      final result2 =
+          GetUsersOptionalResponse.fromResponse(usersOptionalData, ctx: ctx);
+      final result3 = GetUsersOptionalResponse.fromResponse(
+          usersOptionalNullData,
+          ctx: ctx);
+      final result4 = GetUsersOptionalResponse.fromResponse(
+          usersOptionalNullData,
+          ctx: ctx);
+
+      expect(result1, equals(result2));
+      expect(result3, equals(result4));
+      expect(result1, isNot(equals(result3)));
+    });
+
+    test('usersOptional cacheNormalization - null to some', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetUsersOptionalResponse.fromResponseImpl(
+        usersOptionalNullData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersOptionalResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetUsersOptionalResponse.fromResponse(
+        usersOptionalData,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersOptional?.length, 2);
+    });
+
+    test('usersOptional cacheNormalization - some to null', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetUsersOptionalResponse.fromResponseImpl(
+        usersOptionalData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersOptionalResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetUsersOptionalResponse.fromResponse(
+        usersOptionalNullData,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersOptional, isNull);
+    });
+
+    test('usersOptional cacheNormalization - some to some', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetUsersOptionalResponse.fromResponseImpl(
+        usersOptionalData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetUsersOptionalResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetUsersOptionalResponse.fromResponse(
+        usersOptionalDataChanged,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.usersOptional?[0].name, "Alice Updated");
+    });
+  });
+
+  final optionalUsersData = {
+    "optionalUsers": [
+      {"id": "1", "name": "Alice"},
+      {"id": "2", "name": "Bob"},
+    ],
+  };
+
+  final optionalUsersDataChanged = {
+    "optionalUsers": [
+      {"id": "1", "name": "Alice Modified"},
+      {"id": "2", "name": "Bob"},
+    ],
+  };
+
+  group('Optional Objects in List', () {
+    test('optionalUsers deserialize', () {
+      final result = GetOptionalUsersResponse.fromResponse(optionalUsersData);
+      expect(result.optionalUsers?.length, 2);
+      expect(result.optionalUsers?[0]?.id, "1");
+      expect(result.optionalUsers?[0]?.name, "Alice");
+    });
+
+    test('optionalUsers toJson', () {
+      final initial = GetOptionalUsersResponse.fromResponse(optionalUsersData);
+      final json = initial.toJson();
+      expect(json, optionalUsersData);
+    });
+
+    test('optionalUsers equals', () {
+      final ctx = ShalomCtx.withCapacity();
+      final result1 =
+          GetOptionalUsersResponse.fromResponse(optionalUsersData, ctx: ctx);
+      final result2 =
+          GetOptionalUsersResponse.fromResponse(optionalUsersData, ctx: ctx);
+      final result3 = GetOptionalUsersResponse.fromResponse(
+          optionalUsersDataChanged,
+          ctx: ctx);
+
+      expect(result1, equals(result2));
+      expect(result1, isNot(equals(result3)));
+    });
+
+    test('optionalUsers cacheNormalization', () async {
+      final ctx = ShalomCtx.withCapacity();
+      var (result, updateCtx) = GetOptionalUsersResponse.fromResponseImpl(
+        optionalUsersData,
+        ctx,
+      );
+
+      final hasChanged = Completer<bool>();
+
+      final sub = ctx.subscribe(updateCtx.dependantRecords);
+      sub.streamController.stream.listen((newCtx) {
+        result = GetOptionalUsersResponse.fromCache(newCtx);
+        hasChanged.complete(true);
+      });
+
+      final nextResult = GetOptionalUsersResponse.fromResponse(
+        optionalUsersDataChanged,
+        ctx: ctx,
+      );
+
+      await hasChanged.future.timeout(Duration(seconds: 1));
+      expect(result, equals(nextResult));
+      expect(result.optionalUsers?[0]?.name, "Alice Modified");
+    });
+  });
+}

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -1,11 +1,7 @@
 use anyhow::Result;
 use lazy_static::lazy_static;
 use log::{error, info};
-use minijinja::{
-    context,
-    value::{Object, ViaDeserialize},
-    Environment,
-};
+use minijinja::{context, value::ViaDeserialize, Environment};
 use serde::Serialize;
 use shalom_core::{
     context::SharedShalomGlobalContext,
@@ -393,32 +389,25 @@ fn register_default_template_fns<'a>(
         },
     );
 
- 
-
     Ok(())
 }
 
-
-
 /// if the operation contains variables and the selection is from this operation
 /// i.e not from a fragment returns true.
-fn selection_kind_uses_variables<T: ExecutableContext>(ctx: &T,
+fn selection_kind_uses_variables<T: ExecutableContext>(
+    ctx: &T,
     selection_kind: &shalom_core::operation::types::SelectionKind,
 ) -> bool {
     use shalom_core::operation::types::SelectionKind;
-    if !ctx.has_variables(){
+    if !ctx.has_variables() {
         return false;
     }
-    return match selection_kind {
-        SelectionKind::Object(obj) => {
-            ctx.get_selection(&obj.full_name).is_some()
-        }
+    match selection_kind {
+        SelectionKind::Object(obj) => ctx.get_selection(&obj.full_name).is_some(),
         SelectionKind::List(list) => selection_kind_uses_variables(ctx, &list.of_kind),
-        SelectionKind::Union(union) => {
-            ctx.get_union_types().contains_key(&union.full_name)
-        }
+        SelectionKind::Union(union) => ctx.get_union_types().contains_key(&union.full_name),
         _ => false,
-    };
+    }
 }
 
 fn get_field_name_with_args(

--- a/rust/shalom_dart_codegen/templates/fragment.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/fragment.dart.jinja
@@ -8,7 +8,7 @@
 
 {% include "selection_macros" %}
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers, unnecessary_cast
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // Fragment: {{fragment_name}}
 

--- a/rust/shalom_dart_codegen/templates/operation.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation.dart.jinja
@@ -4,7 +4,7 @@
 {% set op_variables_exist = op_variables | length > 0 %}
 
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers, unnecessary_cast
 
 import "{{ schema_import_path }}";
 {% for path, namespace_alias in extra_imports | items -%}

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -370,9 +370,9 @@
                             ```json
                             "ROOT_QUERY.some_field": "{<id>, <typename>}"
                             ```
-                            and subscribers that migt listen to
+                            and subscribers that might listen to
                             `<sometype>:<id>` key. and they won't get updated when the type / id has changed.
-                            since the subscribers does listen to the field path i.e `ROOT_QUERY.some_field` we emit changess on that path if an id or typename has changed.
+                            since the subscribers does listen to the field path i.e `ROOT_QUERY.some_field` we emit changes on that path if an id or typename has changed.
                             #}
                             final normalized$objRecrord = NormalizedObjectRecord(typename: data["__typename"], id: this$normalizedID_temp!);
                             // if id or typename changed we mark the whole selection as changed.

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -88,12 +88,10 @@
 
         for (int i = 0; i < {{selection_name}}$rawList.length; i++) {
             final item$raw = {{selection_name}}$rawList[i];
-            final item$cached = {{selection_name}}$cachedList != null && i < {{selection_name}}$cachedList.length ? {{selection_name}}$cachedList[i] : null;
+            final item$cached = {{selection_name}}$cachedList?.atOpt(i);
             final item$normalizedKey = "${ {{normalized_key}}}[$i]";
-            final item$normalizedID = "${ {{this_normalized_id}}}.${item$normalizedKey}";
 
             {# Recursively normalize the item - macro handles ALL logic including storing the result #}
-            {# Pass list's normalized_id for change detection - if item changes, mark the list as changed #}
             {{ normalize_selection_in_cache(inner_selection, selection_name + "$item", "item$cached", "item$raw", "item$normalizedKey", normalized_id, this_normalized_record, this_normalized_id, ctx) }}
 
             {# Simply read the normalized result stored by the macro and add to list #}

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -9,18 +9,18 @@
         #}
         if ({{cached_sym}} == null){
             {{ctx}}.addChangedRecord({{normalized_id}});
-        }  
+        }
 
         {{selection.full_name}}.normalize$inCache(
             {{raw_sym}} as JsonObject,
             {{ctx}},
-            {% if selection_kind_uses_variables(selection) %}{{ operation_name }}Variables variables,{% endif %}
+            {{"variables,"  if selection_kind_uses_variables(selection)}}
             this$cached: {{cached_sym}} is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord({{cached_sym}}.normalizedID()): {{cached_sym}},
             this$fieldName: {{normalized_key}},
             parent$record: {{this_normalized_record}},
             parent$normalizedID: {{this_normalized_id}}
         );
-        
+
         {# Store the normalized representation in parent record #}
         {% set id_field = get_id_selection(selection.full_name) %}
         {% if id_field is not none %}
@@ -38,9 +38,9 @@
         {% else %}
             {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
         {% endif %}
-        
-  
-  
+
+
+
     {% elif selection.kind == "Union" %}
         if ({{cached_sym}} == null){
             {{ctx}}.addChangedRecord({{normalized_id}});
@@ -48,7 +48,7 @@
         {{selection.full_name}}.normalize$inCache(
             {{raw_sym}} as JsonObject,
             {{ctx}},
-            {% if op_variables_exist %}{{ operation_name }}Variables variables,{% endif %}
+            {{"variables,"  if selection_kind_uses_variables(selection)}}
             this$cached: {{cached_sym}} is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord({{cached_sym}}.normalizedID()): {{cached_sym}},
             this$fieldName: {{normalized_key}},
             parent$record: {{this_normalized_record}},
@@ -195,13 +195,13 @@
             {% if  id_field is not none -%}
                 {{selection.full_name}}.fromCached(
                     ctx.getCachedRecord(({{value_symbol}} as NormalizedObjectRecord).normalizedID()),
-                    ctx,
+                    ctx
                     {{", variables" if selection_kind_uses_variables(selection)}}
                 )
             {% else %}
                 {{ selection.full_name }}.fromCached(
                     {{value_symbol}},
-                    ctx,
+                    ctx
                     {{", variables" if selection_kind_uses_variables(selection)}}
                 )
             {% endif -%}
@@ -224,11 +224,10 @@
     {% elif selection.kind == "List" %}
         {% set inner_selection = selection.of_kind %}
         {# List - recursively deserialize each item via the macro #}
-        {% if is_optional -%} 
-            {{ value_symbol }} == null ? null : 
-        {% else -%}
-            ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
+        {% if is_optional -%}
+            {{ value_symbol }} == null ? null :
         {% endif -%}
+            ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
     {% else %}
         {% if is_optional %}
             {{ value_symbol }} as {{ dart_type_for_scalar_name(selection.concrete_type.name) }}?
@@ -377,7 +376,7 @@
                             #}
                             final normalized$objRecrord = NormalizedObjectRecord(typename: data["__typename"], id: this$normalizedID_temp!);
                             // if id or typename changed we mark the whole selection as changed.
-                            if (this$cached != null && this$cached as NormalizedObjectRecord != normalized$objRecrord){
+                            if (this$cached != null && this$cached is NormalizedObjectRecord && this$cached as NormalizedObjectRecord != normalized$objRecrord){
                                 ctx.addChangedRecord("${parent$normalizedID}.${this$fieldName}");
                             }
                             parent$record[this$fieldName] = normalized$objRecrord;
@@ -385,7 +384,7 @@
                         {% else %}
                             final normalized$objRecrord = NormalizedObjectRecord(typename: "{{selection_object.concrete_typename}}", id: this$normalizedID_temp!);
                             final this$cached = parent$record[this$fieldName];
-                            if (this$cached != null && this$cached as NormalizedObjectRecord != normalized$objRecrord){
+                            if (this$cached != null && this$cached is NormalizedObjectRecord && this$cached as NormalizedObjectRecord != normalized$objRecrord){
                                 ctx.addChangedRecord("${parent$normalizedID}.${this$fieldName}");
                             }
                             parent$record[this$fieldName] = normalized$objRecrord;
@@ -570,7 +569,7 @@
                     {{ full_name }}_{{ type_condition }}.normalize$inCache(
                         data,
                         ctx,
-                        this$cached: {{cached_sym}} is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord({{cached_sym}}.normalizedID()): {{cached_sym}},
+                        this$cached: this$cached is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord((this$cached as NormalizedObjectRecord).normalizedID()): this$cached,
                         this$fieldName: this$fieldName,
                         parent$record: parent$record,
                         parent$normalizedID: parent$normalizedID

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -9,17 +9,18 @@
         #}
         if ({{cached_sym}} == null){
             {{ctx}}.addChangedRecord({{normalized_id}});
-        }
+        }  
 
         {{selection.full_name}}.normalize$inCache(
             {{raw_sym}} as JsonObject,
             {{ctx}},
-            {% if selection.arguments is defined %}{% if selection_uses_variables(selection) %}variables,{% endif %}{% else %}{% if object_uses_variables(selection.full_name) %}variables,{% endif %}{% endif %}
+            {% if selection_kind_uses_variables(selection) %}{{ operation_name }}Variables variables,{% endif %}
+            this$cached: {{cached_sym}} is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord({{cached_sym}}.normalizedID()): {{cached_sym}},
             this$fieldName: {{normalized_key}},
             parent$record: {{this_normalized_record}},
             parent$normalizedID: {{this_normalized_id}}
         );
-
+        
         {# Store the normalized representation in parent record #}
         {% set id_field = get_id_selection(selection.full_name) %}
         {% if id_field is not none %}
@@ -37,6 +38,9 @@
         {% else %}
             {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
         {% endif %}
+        
+  
+  
     {% elif selection.kind == "Union" %}
         if ({{cached_sym}} == null){
             {{ctx}}.addChangedRecord({{normalized_id}});
@@ -44,7 +48,8 @@
         {{selection.full_name}}.normalize$inCache(
             {{raw_sym}} as JsonObject,
             {{ctx}},
-            {% if selection.arguments is defined %}{% if selection_uses_variables(selection) %}variables,{% endif %}{% else %}{% if object_uses_variables(selection.full_name) %}variables,{% endif %}{% endif %}
+            {% if op_variables_exist %}{{ operation_name }}Variables variables,{% endif %}
+            this$cached: {{cached_sym}} is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord({{cached_sym}}.normalizedID()): {{cached_sym}},
             this$fieldName: {{normalized_key}},
             parent$record: {{this_normalized_record}},
             parent$normalizedID: {{this_normalized_id}}
@@ -176,27 +181,39 @@
             {% if id_field is not none -%}
                 {{selection.full_name}}.fromCached(
                     ctx.getCachedRecord(({{value_symbol}} as NormalizedObjectRecord).normalizedID()),
-                    ctx{% if selection_uses_variables(selection) %}, variables{% endif %}
+                    ctx 
+                    {{", variables" if selection_kind_uses_variables(selection)}}
                 )
             {% else %}
-            {{ selection.full_name }}.fromCached({{ value_symbol }}, ctx{% if selection_uses_variables(selection) %}, variables{% endif %})
+            {{ selection.full_name }}.fromCached(
+                {{ value_symbol }},
+                ctx
+                {{", variables" if selection_kind_uses_variables(selection)}}
+            )
             {% endif -%}
         {% else %}
             {% if  id_field is not none -%}
-                {{selection.full_name}}.fromCached(ctx.getCachedRecord(({{value_symbol}} as NormalizedObjectRecord).normalizedID()), ctx{% if selection_uses_variables(selection) %}, variables{% endif %})
+                {{selection.full_name}}.fromCached(
+                    ctx.getCachedRecord(({{value_symbol}} as NormalizedObjectRecord).normalizedID()),
+                    ctx,
+                    {{", variables" if selection_kind_uses_variables(selection)}}
+                )
             {% else %}
-                {{ selection.full_name }}.fromCached({{value_symbol}}, ctx{% if selection_uses_variables(selection) %}, variables{% endif %})
+                {{ selection.full_name }}.fromCached(
+                    {{value_symbol}},
+                    ctx,
+                    {{", variables" if selection_kind_uses_variables(selection)}}
+                )
             {% endif -%}
         {% endif %}
     {% elif selection.kind == "Union" %}
-        
         {% if is_optional %}
-            {{ value_symbol }} == null ? null : 
+            {{ value_symbol }} == null ? null :
         {% endif -%}
                 ({{value_symbol}} is  NormalizedObjectRecord)?
                     {{ selection.full_name }}.fromCached(({{value_symbol}} as NormalizedObjectRecord).normalizedID(), ctx)
                 : {{ selection.full_name }}.fromCached({{ value_symbol }}, ctx)
-                
+
     {% elif selection.kind == "Enum" %}
         {% set typename = selection.concrete_type.name %}
         {% if is_optional %}
@@ -206,32 +223,12 @@
         {% endif %}
     {% elif selection.kind == "List" %}
         {% set inner_selection = selection.of_kind %}
-        {% if inner_selection.kind == "Object" %}
-            {# List of objects - handle normalized vs non-normalized #}
-            {% set id_field = get_id_selection(inner_selection.full_name) %}
-            {% if id_field is not none %}
-                {# Normalized objects - stored as NormalizedObjectRecord references #}
-                {% if is_optional %}
-                    {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(ctx.getCachedRecord((e as NormalizedObjectRecord).normalizedID()), ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
-                {% else %}
-                    ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(ctx.getCachedRecord((e as NormalizedObjectRecord).normalizedID()), ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
-                {% endif %}
-            {% else %}
-                {# Non-normalized objects - stored as direct data #}
-                {% if is_optional %}
-                    {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(e, ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
-                {% else %}
-                    ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(e, ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
-                {% endif %}
-            {% endif %}
-        {% else %}
-            {# List of scalars or other non-object types #}
-            {% if is_optional %}
-                {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
-            {% else %}
-                ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
-            {% endif %}
-        {% endif %}
+        {# List - recursively deserialize each item via the macro #}
+        {% if is_optional -%} 
+            {{ value_symbol }} == null ? null : 
+        {% else -%}
+            ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
+        {% endif -%}
     {% else %}
         {% if is_optional %}
             {{ value_symbol }} as {{ dart_type_for_scalar_name(selection.concrete_type.name) }}?
@@ -340,11 +337,12 @@
 
         static void normalize$inCache(JsonObject data,
                 CacheUpdateContext ctx,
-                {% if not is_union_member and selection_uses_variables(selection_object) %} {{ operation_name }}Variables variables,{% endif %}
+                {% if not is_union_member and selection_kind_uses_variables(selection_object) %} {{ operation_name }}Variables variables,{% endif %}
                 {% if not is_root_selection -%}
                     {
                     /// can be just the selection name but also may include serialized arguments.
                     required RecordID  this$fieldName,
+                    required JsonObject? this$cached,
                     required JsonObject parent$record,
                     required RecordID parent$normalizedID
                     }
@@ -369,19 +367,15 @@
                     } else {
                         {% if is_union_member -%}
                             {#
-                            improve how we deduce changes in normalized objects when the whole id has changed.
                             since the object is normalized like so
                             ```json
                             "ROOT_QUERY.some_field": "{<id>, <typename>}"
                             ```
-                            since up until now we only pushed updates for null->some changes on objects and sub object fields.
-                            even if the inner object fields have changed. since it is normalized
-                            previouse subscribers would listen to
-                            `<sometype>:<id>` key. and they won't get updated.
-                            now, since the subscribers does listen to the field path i.e `ROOT_QUERY.some_field` we emit changess on that path if an id or typename has changed.
+                            and subscribers that migt listen to
+                            `<sometype>:<id>` key. and they won't get updated when the type / id has changed.
+                            since the subscribers does listen to the field path i.e `ROOT_QUERY.some_field` we emit changess on that path if an id or typename has changed.
                             #}
                             final normalized$objRecrord = NormalizedObjectRecord(typename: data["__typename"], id: this$normalizedID_temp!);
-                            final this$cached = parent$record[this$fieldName];
                             // if id or typename changed we mark the whole selection as changed.
                             if (this$cached != null && this$cached as NormalizedObjectRecord != normalized$objRecrord){
                                 ctx.addChangedRecord("${parent$normalizedID}.${this$fieldName}");
@@ -437,9 +431,9 @@
             {% endfor -%}
         }
         {% if not is_root_selection -%}
-        static {{typename}} fromCached(NormalizedRecordData data, ShalomCtx ctx{% if not is_union_member and selection_uses_variables(selection_object)  %}, {{ operation_name }}Variables variables{% endif %}) {
+        static {{typename}} fromCached(NormalizedRecordData data, ShalomCtx ctx{% if not is_union_member and selection_kind_uses_variables(selection_object)  %}, {{ operation_name }}Variables variables{% endif %}) {
         {% else -%}
-        static {{typename}} fromCache(ShalomCtx ctx{% if selection_uses_variables(selection_object) -%}, {{ operation_name }}Variables variables{% endif %}) {
+        static {{typename}} fromCache(ShalomCtx ctx{% if selection_kind_uses_variables(selection_object) -%}, {{ operation_name }}Variables variables{% endif %}) {
         {% endif -%}
             {% if is_root_selection -%}
                 final data = ctx.getCachedRecord("ROOT_{{OP_TYPE}}");
@@ -565,7 +559,8 @@
             {
                 required RecordID this$fieldName,
                 required JsonObject parent$record,
-                required RecordID parent$normalizedID
+                required RecordID parent$normalizedID,
+                required JsonObject? this$cached
             }
         ) {
             final typename = data["__typename"] as String;
@@ -575,6 +570,7 @@
                     {{ full_name }}_{{ type_condition }}.normalize$inCache(
                         data,
                         ctx,
+                        this$cached: {{cached_sym}} is NormalizedObjectRecord ? ctx.shalomContext.getCachedRecord({{cached_sym}}.normalizedID()): {{cached_sym}},
                         this$fieldName: this$fieldName,
                         parent$record: parent$record,
                         parent$normalizedID: parent$normalizedID

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -1,4 +1,123 @@
 
+{# Macro to normalize a selection in cache - handles Object, Union, List, Scalar, etc. #}
+{% macro normalize_selection_in_cache(selection, selection_name, cached_sym, raw_sym, normalized_key, normalized_id, this_normalized_record, this_normalized_id, ctx="ctx") -%}
+    {% if selection.kind == "Object" %}
+        {# object selections can be subscribed to,
+            but will only get updates for null<->some changes. sub fields should be subscribed by themself
+           if this object is normalized and the id has changed we should also notify for change
+           in the normalize$inCache function
+        #}
+        if ({{cached_sym}} == null){
+            {{ctx}}.addChangedRecord({{normalized_id}});
+        }
+
+        {{selection.full_name}}.normalize$inCache(
+            {{raw_sym}} as JsonObject,
+            {{ctx}},
+            {% if selection.arguments is defined %}{% if selection_uses_variables(selection) %}variables,{% endif %}{% else %}{% if object_uses_variables(selection.full_name) %}variables,{% endif %}{% endif %}
+            this$fieldName: {{normalized_key}},
+            parent$record: {{this_normalized_record}},
+            parent$normalizedID: {{this_normalized_id}}
+        );
+
+        {# Store the normalized representation in parent record #}
+        {% set id_field = get_id_selection(selection.full_name) %}
+        {% if id_field is not none %}
+            final {{selection_name}}$id = ({{raw_sym}} as JsonObject)["{{id_field.name}}"] as RecordID?;
+            if ({{selection_name}}$id != null) {
+                final {{selection_name}}$normalized = NormalizedObjectRecord(typename: "{{selection.concrete_typename}}", id: {{selection_name}}$id);
+                {{this_normalized_record}}[{{normalized_key}}] = {{selection_name}}$normalized;
+                {# Check if the reference changed #}
+                if ({{cached_sym}} != null && {{cached_sym}} is NormalizedObjectRecord && {{cached_sym}} != {{selection_name}}$normalized) {
+                    {{ctx}}.addChangedRecord({{normalized_id}});
+                }
+            } else {
+                {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
+            }
+        {% else %}
+            {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
+        {% endif %}
+    {% elif selection.kind == "Union" %}
+        if ({{cached_sym}} == null){
+            {{ctx}}.addChangedRecord({{normalized_id}});
+        }
+        {{selection.full_name}}.normalize$inCache(
+            {{raw_sym}} as JsonObject,
+            {{ctx}},
+            {% if selection.arguments is defined %}{% if selection_uses_variables(selection) %}variables,{% endif %}{% else %}{% if object_uses_variables(selection.full_name) %}variables,{% endif %}{% endif %}
+            this$fieldName: {{normalized_key}},
+            parent$record: {{this_normalized_record}},
+            parent$normalizedID: {{this_normalized_id}}
+        );
+
+        {# Store the normalized representation in parent record #}
+        {% set first_member = selection.inline_fragments | items | first %}
+        {% if first_member %}
+            {% set id_field = get_id_selection(first_member[1].full_name) %}
+            {% if id_field is not none %}
+                final {{selection_name}}$id = ({{raw_sym}} as JsonObject)["{{id_field.name}}"] as RecordID?;
+                final {{selection_name}}$typename = ({{raw_sym}} as JsonObject)["__typename"] as String?;
+                if ({{selection_name}}$id != null && {{selection_name}}$typename != null) {
+                    final {{selection_name}}$normalized = NormalizedObjectRecord(typename: {{selection_name}}$typename, id: {{selection_name}}$id);
+                    {{this_normalized_record}}[{{normalized_key}}] = {{selection_name}}$normalized;
+                    {# Check if the reference changed #}
+                    if ({{cached_sym}} != null && {{cached_sym}} is NormalizedObjectRecord && {{cached_sym}} != {{selection_name}}$normalized) {
+                        {{ctx}}.addChangedRecord({{normalized_id}});
+                    }
+                } else {
+                    {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
+                }
+            {% else %}
+                {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
+            {% endif %}
+        {% else %}
+            {{this_normalized_record}}[{{normalized_key}}] = getOrCreateObject({{this_normalized_record}}, {{normalized_key}});
+        {% endif %}
+    {% elif selection.kind == "List" %}
+        {% set inner_selection = selection.of_kind %}
+        {# List - recursively normalize each item via the macro #}
+        final {{selection_name}}$rawList = {{raw_sym}} as List<dynamic>;
+        final {{selection_name}}$cachedList = {{cached_sym}} as List<dynamic>?;
+
+        {# Check if list length changed #}
+        if ({{selection_name}}$cachedList == null || {{selection_name}}$cachedList.length != {{selection_name}}$rawList.length) {
+            {{ctx}}.addChangedRecord({{normalized_id}});
+        }
+
+        final {{selection_name}}$normalizedList = <dynamic>[];
+
+        for (int i = 0; i < {{selection_name}}$rawList.length; i++) {
+            final item$raw = {{selection_name}}$rawList[i];
+            final item$cached = {{selection_name}}$cachedList != null && i < {{selection_name}}$cachedList.length ? {{selection_name}}$cachedList[i] : null;
+            final item$normalizedKey = "${ {{normalized_key}}}[$i]";
+            final item$normalizedID = "${ {{this_normalized_id}}}.${item$normalizedKey}";
+
+            {# Recursively normalize the item - macro handles ALL logic including storing the result #}
+            {# Pass list's normalized_id for change detection - if item changes, mark the list as changed #}
+            {{ normalize_selection_in_cache(inner_selection, selection_name + "$item", "item$cached", "item$raw", "item$normalizedKey", normalized_id, this_normalized_record, this_normalized_id, ctx) }}
+
+            {# Simply read the normalized result stored by the macro and add to list #}
+            {% if inner_selection.kind == "Scalar" or inner_selection.kind == "Enum" %}
+                {# For scalars/enums, add the raw value directly #}
+                {{selection_name}}$normalizedList.add(item$raw);
+            {% else %}
+                {# For everything else (Object/Union/List), macro stored it - just read and add #}
+                {{selection_name}}$normalizedList.add({{this_normalized_record}}[item$normalizedKey]);
+            {% endif %}
+        }
+
+        {{this_normalized_record}}[{{normalized_key}}] = {{selection_name}}$normalizedList;
+    {% else %}
+        {# Scalar, Enum, or other types #}
+        if (
+            {{selection_equality_comparison_macro(selection, cached_sym, raw_sym, ne=True)}}
+        ){
+            {{ctx}}.addChangedRecord({{normalized_id}});
+        }
+        {{this_normalized_record}}[{{normalized_key}}] = {{raw_sym}};
+    {% endif %}
+{%- endmacro %}
+
     {% macro if_op_variables(insert) %}
     {% if op_variables_exist -%} {{insert}}
     {% endif -%}
@@ -319,114 +438,7 @@
                 final {{selection.name}}$cached = this$NormalizedRecord[{{selection.name}}Normalized$Key];
                 final {{selection.name}}$raw = data["{{selection.name}}"];
                 if ({{selection.name}}$raw != null){
-                    {% if selection.kind == "Object" %}
-                        {# object selections can be subscribed to,
-                            but will only get updates for null<->some changes. sub fields should be subscribed by themself
-                           if this object is normalized and the id has changed we should also notify for change
-                           in the normalize$inCache function
-                        #}
-                        if ({{selection.name}}$cached == null){
-                            ctx.addChangedRecord({{selection.name}}$normalizedID);
-                        }
-
-                        {{selection.full_name}}.normalize$inCache(
-                            {{selection.name}}$raw as JsonObject,
-                            ctx,
-                            {% if selection_uses_variables(selection) %}variables,{% endif %}
-                            this$fieldName: {{selection.name}}Normalized$Key,
-                            parent$record: this$NormalizedRecord,
-                            parent$normalizedID: this$normalizedID
-                        );
-                    {% elif selection.kind == "Union" %}
-                        if ({{selection.name}}$cached == null){
-                            ctx.addChangedRecord({{selection.name}}$normalizedID);
-                        }
-                        {{selection.full_name}}.normalize$inCache(
-                            {{selection.name}}$raw as JsonObject,
-                            ctx,
-                            {% if selection_uses_variables(selection) %}variables,{% endif %}
-                            this$fieldName: {{selection.name}}Normalized$Key,
-                            parent$record: this$NormalizedRecord,
-                            parent$normalizedID: this$normalizedID
-                        );
-                    {% elif selection.kind == "List" %}
-                        {% set inner_selection = selection.of_kind %}
-                        {% if inner_selection.kind == "Object" %}
-                            {# List of objects - need special normalization #}
-                            final {{selection.name}}$rawList = {{selection.name}}$raw as List<dynamic>;
-                            final {{selection.name}}$cachedList = {{selection.name}}$cached as List<dynamic>?;
-
-                            {# Check if list length changed #}
-                            if ({{selection.name}}$cachedList == null || {{selection.name}}$cachedList.length != {{selection.name}}$rawList.length) {
-                                ctx.addChangedRecord({{selection.name}}$normalizedID);
-                            }
-
-                            final {{selection.name}}$normalizedList = <dynamic>[];
-
-                            for (int i = 0; i < {{selection.name}}$rawList.length; i++) {
-                                final item$raw = {{selection.name}}$rawList[i] as JsonObject;
-
-                                {# Normalize each object #}
-                                {{inner_selection.full_name}}.normalize$inCache(
-                                    item$raw,
-                                    ctx,
-                                    {% if object_uses_variables(inner_selection.full_name) %}variables,{% endif %}
-                                    this$fieldName: "${ {{selection.name}}Normalized$Key}[$i]",
-                                    parent$record: this$NormalizedRecord,
-                                    parent$normalizedID: this$normalizedID
-                                );
-
-                                {# Store the normalized reference #}
-                                {% set id_field = get_id_selection(inner_selection.full_name) %}
-                                {% if id_field is not none %}
-                                    final item$id = item$raw["{{id_field.name}}"] as RecordID?;
-                                    if (item$id != null) {
-                                        final normalized$objRecord = NormalizedObjectRecord(typename: "{{inner_selection.concrete_typename}}", id: item$id);
-                                        {{selection.name}}$normalizedList.add(normalized$objRecord);
-
-                                        {# Check if object at this index changed ID #}
-                                        if ({{selection.name}}$cachedList != null && i < {{selection.name}}$cachedList.length) {
-                                            final cached$item = {{selection.name}}$cachedList[i];
-                                            if (cached$item is NormalizedObjectRecord && cached$item != normalized$objRecord) {
-                                                ctx.addChangedRecord({{selection.name}}$normalizedID);
-                                            }
-                                        }
-                                    } else {
-                                        {# Non-normalized object without ID, store inline data #}
-                                        final item$fieldName = "${ {{selection.name}}Normalized$Key}[$i]";
-                                        final item$data = getOrCreateObject(this$NormalizedRecord, item$fieldName);
-                                        {{selection.name}}$normalizedList.add(item$data);
-                                    }
-                                {% else %}
-                                    {# Non-normalized object, store inline data #}
-                                    final item$fieldName = "${ {{selection.name}}Normalized$Key}[$i]";
-                                    final item$data = getOrCreateObject(this$NormalizedRecord, item$fieldName);
-                                    {{selection.name}}$normalizedList.add(item$data);
-                                {% endif %}
-                            }
-
-                            this$NormalizedRecord[{{selection.name}}Normalized$Key] = {{selection.name}}$normalizedList;
-                        {% else %}
-                            {# List of scalars or other non-object types #}
-                            {% set cached_sym %} {{selection.name}}$cached {% endset %}
-                            {% set raw_sym %} {{selection.name}}$raw {% endset %}
-                            if (
-                                {{selection_equality_comparison_macro(selection, cached_sym, raw_sym, ne=True)}}
-                            ){
-                                ctx.addChangedRecord({{selection.name}}$normalizedID);
-                            }
-                            this$NormalizedRecord[{{selection.name}}Normalized$Key] = {{selection.name}}$raw;
-                        {% endif %}
-                    {% else %}
-                        {% set cached_sym %} {{selection.name}}$cached {% endset %}
-                        {% set raw_sym %} {{selection.name}}$raw {% endset %}
-                        if (
-                            {{selection_equality_comparison_macro(selection, cached_sym, raw_sym, ne=True)}}
-                        ){
-                            ctx.addChangedRecord({{selection.name}}$normalizedID);
-                        }
-                        this$NormalizedRecord[{{selection.name}}Normalized$Key] = {{selection.name}}$raw;
-                    {% endif %}
+                    {{ normalize_selection_in_cache(selection, selection.name, selection.name + "$cached", selection.name + "$raw", selection.name + "Normalized$Key", selection.name + "$normalizedID", "this$NormalizedRecord", "this$normalizedID", "ctx") }}
                 } else if (data.containsKey("{{selection.name}}") && {{selection.name}}$cached != null){
                         // if this field was null in the response and key exists clear the cache.
 

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -94,10 +94,17 @@
         for (int i = 0; i < {{selection_name}}$rawList.length; i++) {
             final item$raw = {{selection_name}}$rawList[i];
             final item$cached = {{selection_name}}$cachedList?.elementAtOrNull(i);
-            final item$normalizedKey = "${ {{normalized_key}}}[$i]";
+            final item$normalizedKey = "$i";
 
             {# Recursively normalize the item - macro handles ALL logic including storing the result #}
-            {{ normalize_selection_in_cache(inner_selection, selection_name + "$item", "item$cached", "item$raw", "item$normalizedKey", normalized_id, this_normalized_record, this_normalized_id, ctx) }}
+            {{ normalize_selection_in_cache(inner_selection,
+                selection_name + "$item",
+                "item$cached", "item$raw",
+                "item$normalizedKey",
+                normalized_id,
+                this_normalized_record,
+                this_normalized_id,
+                ctx) }}
 
             {# Simply read the normalized result stored by the macro and add to list #}
             {% if inner_selection.kind == "Scalar" or inner_selection.kind == "Enum" %}

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -93,7 +93,7 @@
 
         for (int i = 0; i < {{selection_name}}$rawList.length; i++) {
             final item$raw = {{selection_name}}$rawList[i];
-            final item$cached = {{selection_name}}$cachedList?.atOpt(i);
+            final item$cached = {{selection_name}}$cachedList?.elementAtOrNull(i);
             final item$normalizedKey = "${ {{normalized_key}}}[$i]";
 
             {# Recursively normalize the item - macro handles ALL logic including storing the result #}
@@ -383,7 +383,6 @@
                             this$normalizedID = normalized$objRecrord.normalizedID();
                         {% else %}
                             final normalized$objRecrord = NormalizedObjectRecord(typename: "{{selection_object.concrete_typename}}", id: this$normalizedID_temp!);
-                            final this$cached = parent$record[this$fieldName];
                             if (this$cached != null && this$cached is NormalizedObjectRecord && this$cached as NormalizedObjectRecord != normalized$objRecrord){
                                 ctx.addChangedRecord("${parent$normalizedID}.${this$fieldName}");
                             }

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -191,27 +191,14 @@
             {% endif -%}
         {% endif %}
     {% elif selection.kind == "Union" %}
-        {# Check if any union member has an ID (is normalized) by checking the first one #}
-        {% set first_member = selection.inline_fragments | items | first %}
-        {% if first_member %}
-            {% set first_member_has_id = get_id_selection(first_member[1].full_name) %}
-        {% else %}
-            {% set first_member_has_id = none %}
-        {% endif %}
+        
         {% if is_optional %}
-            {{ value_symbol }} == null ? null :
-            {% if first_member_has_id -%}
-                {{ selection.full_name }}.fromCached(({{value_symbol}} as NormalizedObjectRecord).normalizedID(), ctx)
-            {%- else -%}
-                {{ selection.full_name }}.fromCached({{ value_symbol }}, ctx)
-            {%- endif %}
-        {% else %}
-            {% if first_member_has_id -%}
-                {{ selection.full_name }}.fromCached(({{value_symbol}} as NormalizedObjectRecord).normalizedID(), ctx)
-            {%- else -%}
-                {{ selection.full_name }}.fromCached({{ value_symbol }}, ctx)
-            {%- endif %}
-        {% endif %}
+            {{ value_symbol }} == null ? null : 
+        {% endif -%}
+                ({{value_symbol}} is  NormalizedObjectRecord)?
+                    {{ selection.full_name }}.fromCached(({{value_symbol}} as NormalizedObjectRecord).normalizedID(), ctx)
+                : {{ selection.full_name }}.fromCached({{ value_symbol }}, ctx)
+                
     {% elif selection.kind == "Enum" %}
         {% set typename = selection.concrete_type.name %}
         {% if is_optional %}

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -102,10 +102,31 @@
         {% endif %}
     {% elif selection.kind == "List" %}
         {% set inner_selection = selection.of_kind %}
-        {% if is_optional %}
-            {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
+        {% if inner_selection.kind == "Object" %}
+            {# List of objects - handle normalized vs non-normalized #}
+            {% set id_field = get_id_selection(inner_selection.full_name) %}
+            {% if id_field is not none %}
+                {# Normalized objects - stored as NormalizedObjectRecord references #}
+                {% if is_optional %}
+                    {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(ctx.getCachedRecord((e as NormalizedObjectRecord).normalizedID()), ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
+                {% else %}
+                    ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(ctx.getCachedRecord((e as NormalizedObjectRecord).normalizedID()), ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
+                {% endif %}
+            {% else %}
+                {# Non-normalized objects - stored as direct data #}
+                {% if is_optional %}
+                    {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(e, ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
+                {% else %}
+                    ({{ value_symbol }} as List<dynamic>).map((e) => {{inner_selection.full_name}}.fromCached(e, ctx{% if object_uses_variables(inner_selection.full_name) %}, variables{% endif %})).toList()
+                {% endif %}
+            {% endif %}
         {% else %}
-            ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
+            {# List of scalars or other non-object types #}
+            {% if is_optional %}
+                {{ value_symbol }} == null ? null : ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
+            {% else %}
+                ({{ value_symbol }} as List<dynamic>).map((e) => {{ _deserialize_selection_from_cache_macro("e", inner_selection, false) }}).toList()
+            {% endif %}
         {% endif %}
     {% else %}
         {% if is_optional %}
@@ -244,14 +265,14 @@
                     } else {
                         {% if is_union_member -%}
                             {#
-                            improve how we deduce changes in normalized objects when the whole id has changed. 
-                            since the object is normalized like so 
+                            improve how we deduce changes in normalized objects when the whole id has changed.
+                            since the object is normalized like so
                             ```json
                             "ROOT_QUERY.some_field": "{<id>, <typename>}"
                             ```
                             since up until now we only pushed updates for null->some changes on objects and sub object fields.
                             even if the inner object fields have changed. since it is normalized
-                            previouse subscribers would listen to 
+                            previouse subscribers would listen to
                             `<sometype>:<id>` key. and they won't get updated.
                             now, since the subscribers does listen to the field path i.e `ROOT_QUERY.some_field` we emit changess on that path if an id or typename has changed.
                             #}
@@ -306,8 +327,8 @@
                         #}
                         if ({{selection.name}}$cached == null){
                             ctx.addChangedRecord({{selection.name}}$normalizedID);
-                        } 
-                        
+                        }
+
                         {{selection.full_name}}.normalize$inCache(
                             {{selection.name}}$raw as JsonObject,
                             ctx,
@@ -328,6 +349,74 @@
                             parent$record: this$NormalizedRecord,
                             parent$normalizedID: this$normalizedID
                         );
+                    {% elif selection.kind == "List" %}
+                        {% set inner_selection = selection.of_kind %}
+                        {% if inner_selection.kind == "Object" %}
+                            {# List of objects - need special normalization #}
+                            final {{selection.name}}$rawList = {{selection.name}}$raw as List<dynamic>;
+                            final {{selection.name}}$cachedList = {{selection.name}}$cached as List<dynamic>?;
+
+                            {# Check if list length changed #}
+                            if ({{selection.name}}$cachedList == null || {{selection.name}}$cachedList.length != {{selection.name}}$rawList.length) {
+                                ctx.addChangedRecord({{selection.name}}$normalizedID);
+                            }
+
+                            final {{selection.name}}$normalizedList = <dynamic>[];
+
+                            for (int i = 0; i < {{selection.name}}$rawList.length; i++) {
+                                final item$raw = {{selection.name}}$rawList[i] as JsonObject;
+
+                                {# Normalize each object #}
+                                {{inner_selection.full_name}}.normalize$inCache(
+                                    item$raw,
+                                    ctx,
+                                    {% if object_uses_variables(inner_selection.full_name) %}variables,{% endif %}
+                                    this$fieldName: "${ {{selection.name}}Normalized$Key}[$i]",
+                                    parent$record: this$NormalizedRecord,
+                                    parent$normalizedID: this$normalizedID
+                                );
+
+                                {# Store the normalized reference #}
+                                {% set id_field = get_id_selection(inner_selection.full_name) %}
+                                {% if id_field is not none %}
+                                    final item$id = item$raw["{{id_field.name}}"] as RecordID?;
+                                    if (item$id != null) {
+                                        final normalized$objRecord = NormalizedObjectRecord(typename: "{{inner_selection.concrete_typename}}", id: item$id);
+                                        {{selection.name}}$normalizedList.add(normalized$objRecord);
+
+                                        {# Check if object at this index changed ID #}
+                                        if ({{selection.name}}$cachedList != null && i < {{selection.name}}$cachedList.length) {
+                                            final cached$item = {{selection.name}}$cachedList[i];
+                                            if (cached$item is NormalizedObjectRecord && cached$item != normalized$objRecord) {
+                                                ctx.addChangedRecord({{selection.name}}$normalizedID);
+                                            }
+                                        }
+                                    } else {
+                                        {# Non-normalized object without ID, store inline data #}
+                                        final item$fieldName = "${ {{selection.name}}Normalized$Key}[$i]";
+                                        final item$data = getOrCreateObject(this$NormalizedRecord, item$fieldName);
+                                        {{selection.name}}$normalizedList.add(item$data);
+                                    }
+                                {% else %}
+                                    {# Non-normalized object, store inline data #}
+                                    final item$fieldName = "${ {{selection.name}}Normalized$Key}[$i]";
+                                    final item$data = getOrCreateObject(this$NormalizedRecord, item$fieldName);
+                                    {{selection.name}}$normalizedList.add(item$data);
+                                {% endif %}
+                            }
+
+                            this$NormalizedRecord[{{selection.name}}Normalized$Key] = {{selection.name}}$normalizedList;
+                        {% else %}
+                            {# List of scalars or other non-object types #}
+                            {% set cached_sym %} {{selection.name}}$cached {% endset %}
+                            {% set raw_sym %} {{selection.name}}$raw {% endset %}
+                            if (
+                                {{selection_equality_comparison_macro(selection, cached_sym, raw_sym, ne=True)}}
+                            ){
+                                ctx.addChangedRecord({{selection.name}}$normalizedID);
+                            }
+                            this$NormalizedRecord[{{selection.name}}Normalized$Key] = {{selection.name}}$raw;
+                        {% endif %}
                     {% else %}
                         {% set cached_sym %} {{selection.name}}$cached {% endset %}
                         {% set raw_sym %} {{selection.name}}$raw {% endset %}

--- a/rust/shalom_dart_codegen/tests/usecases_test.rs
+++ b/rust/shalom_dart_codegen/tests/usecases_test.rs
@@ -36,6 +36,11 @@ fn test_list_of_scalars_dart() {
 }
 
 #[test]
+fn test_list_of_objects_dart() {
+    run_dart_tests_for_usecase("list_of_objects");
+}
+
+#[test]
 fn test_fragments_dart() {
     run_dart_tests_for_usecase("fragments");
 }


### PR DESCRIPTION
### TODO:
- [ ] lists selections may grow unbounded.

## Summary by Sourcery

Enable support for list-of-object selections in the Dart code generator by implementing recursive cache normalization, extending cache deserialization, refactoring variable detection, registering nested selections, and adding comprehensive tests.

New Features:
- Add recursive normalize_selection_in_cache macro to handle Object, Union, and List kinds during cache normalization
- Extend cache deserialization macro to support lists of objects with normalized and non-normalized handling
- Refactor selection variable detection by extracting selection_kind_uses_variables and adding object_uses_variables helper

Enhancements:
- Register inner object and union selections in the GraphQL parser for code generation

Tests:
- Add Dart integration tests, operations, and schema for the list_of_objects use case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nested object/union selections inside list fields are now recognized, improving generated/runtime handling.
  * Executable contexts can be queried for variable presence, enabling variable-aware flows.
  * Unified normalization macro centralizes cache normalization for lists, objects, unions and improves propagation.

* **Bug Fixes**
  * More reliable cache normalization and change detection for lists and nested objects, including identity and length changes.

* **Tests**
  * Added schema, queries, comprehensive Dart tests and a new test runner entry for the list-of-objects use case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->