### PR TITLE
auto inject typename selection

### DIFF
--- a/dart/shalom_core/lib/src/shalom_ctx.dart
+++ b/dart/shalom_core/lib/src/shalom_ctx.dart
@@ -30,7 +30,7 @@ class ShalomCtx {
 
   ShalomCtx({required this.cache});
   ShalomCtx.withCapacity({int capacity = 1000})
-      : cache = NormelizedCache(capacity: capacity);
+    : cache = NormelizedCache(capacity: capacity);
 
   RecordID resolveNodeID(String id) {
     return id.split(":").toString();

--- a/rust/shalom_core/src/entrypoint.rs
+++ b/rust/shalom_core/src/entrypoint.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use apollo_compiler::{validation::Valid, ExecutableDocument};
-use log::{error, info, trace};
+use log::{error, trace};
 
 use crate::{
     context::{ShalomGlobalContext, SharedShalomGlobalContext},

--- a/rust/shalom_core/src/operation/types.rs
+++ b/rust/shalom_core/src/operation/types.rs
@@ -285,7 +285,17 @@ impl MultiTypeSelectionCommon {
     }
 
     pub fn add_shared_selection(&self, selection: Selection) {
-        self.shared_selections.borrow_mut().push(selection);
+        // Check if a selection with this name already exists to avoid duplicates
+        let selection_name = selection.self_selection_name();
+        let already_exists = self
+            .shared_selections
+            .borrow()
+            .iter()
+            .any(|s| s.self_selection_name() == selection_name);
+
+        if !already_exists {
+            self.shared_selections.borrow_mut().push(selection);
+        }
     }
 
     pub fn add_inline_fragment(

--- a/rust/shalom_dart_codegen/dart_tests/test/interface_selection/operations.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/interface_selection/operations.graphql
@@ -95,3 +95,17 @@ query GetAnimalWithArguments($id: ID!, $limit: Int!) {
         }
     }
 }
+
+query GetAnimalWithoutAnyTypename($id: ID!) {
+    animal(id: $id) {
+        id
+        legs
+        sound
+        ... on Lion {
+            furColor
+        }
+        ... on Turtle {
+            shellColor
+        }
+    }
+}

--- a/rust/shalom_dart_codegen/templates/fragment.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/fragment.dart.jinja
@@ -8,7 +8,7 @@
 
 {% include "selection_macros" %}
 
-// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers, unnecessary_cast
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers, unnecessary_cast, unused_element
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // Fragment: {{fragment_name}}
 


### PR DESCRIPTION
## Summary by Sourcery

Automatically inject __typename into GraphQL selection sets for unions and interfaces, eliminating manual presence assertions.

New Features:
- Recursively inject __typename into union and interface selection sets in operations and fragments

Enhancements:
- Remove explicit assertions for __typename presence in union and interface parsing
- Avoid duplicate shared selections by checking existing selection names

Tests:
- Add GraphQL test query without __typename to verify automatic injection

Chores:
- Add `unused_element` to Dart lint ignore directives
- Fix indentation in Dart ShalomCtx.withCapacity initializer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatically injects __typename for union/interface selections, so queries no longer need to include it manually.
* Bug Fixes
  * Prevents duplicate shared selections in operation outputs.
* Tests
  * Added coverage for operations that omit __typename at the top level.
* Style
  * Minor code formatting cleanups.
* Chores
  * Reduced logging verbosity by removing unused info-level logging.
  * Suppressed unused_element lint in generated Dart fragments to reduce noise during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->