### PR TITLE
auto fmt

### DIFF
--- a/rust/shalom_dart_codegen/src/main.rs
+++ b/rust/shalom_dart_codegen/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use notify::{RecursiveMode, Watcher};
 use notify_debouncer_full::new_debouncer;
+use shalom_dart_codegen::CodegenOptions;
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -59,7 +60,11 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::Generate { path, strict, fmt } => {
             log::info!("Running code generation...");
-            shalom_dart_codegen::codegen_entry_point(&path, strict, fmt)?;
+            shalom_dart_codegen::codegen_entry_point(CodegenOptions {
+                pwd: path,
+                strict,
+                fmt,
+            })?;
             log::info!("Code generation completed successfully!");
         }
         Commands::Watch { path, strict, fmt } => {
@@ -75,7 +80,11 @@ fn main() -> Result<()> {
                     .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
                     .is_ok()
                 {
-                    match shalom_dart_codegen::codegen_entry_point(&path, strict, fmt) {
+                    match shalom_dart_codegen::codegen_entry_point(CodegenOptions {
+                        pwd: path.clone(),
+                        strict,
+                        fmt,
+                    }) {
                         Ok(_) => log::info!("Initial code generation completed successfully!"),
                         Err(e) => log::error!("Initial code generation failed: {}", e),
                     }
@@ -124,7 +133,11 @@ fn main() -> Result<()> {
                                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
                                 .is_ok()
                             {
-                                match shalom_dart_codegen::codegen_entry_point(&path, strict, fmt) {
+                                match shalom_dart_codegen::codegen_entry_point(CodegenOptions {
+                                    pwd: path.clone(),
+                                    strict,
+                                    fmt,
+                                }) {
                                     Ok(_) => log::info!("Code generation completed successfully!"),
                                     Err(e) => log::error!("Code generation failed: {}", e),
                                 }

--- a/rust/shalom_dart_codegen/tests/common/mod.rs
+++ b/rust/shalom_dart_codegen/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use shalom_dart_codegen::CodegenOptions;
 use std::path::{Path, PathBuf};
 
 use log::info;
@@ -40,7 +41,12 @@ pub fn ensure_test_folder_exists(usecase: &str) -> anyhow::Result<PathBuf> {
 }
 
 fn run_codegen(cwd: &Path, strict: bool) {
-    shalom_dart_codegen::codegen_entry_point(&Some(cwd.to_path_buf()), strict).unwrap()
+    shalom_dart_codegen::codegen_entry_point(CodegenOptions {
+        pwd: Some(cwd.to_path_buf()),
+        strict,
+        fmt: false,
+    })
+    .unwrap()
 }
 
 pub fn run_dart_tests_for_usecase(usecase: &str) {


### PR DESCRIPTION
## Summary by Sourcery

Add support for auto-formatting generated Dart files via a new CLI flag

New Features:
- Introduce `--fmt` flag to Generate and Watch commands to trigger auto-formatting of generated Dart code

Enhancements:
- Implement `format_generated_files` function to run `dart format` on all `.shalom.dart` files using cross-platform commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --fmt flag to Generate and Watch to automatically format generated Dart files using platform-specific formatting tools; formatting failures are reported but do not abort generation.

* **Behavior Changes**
  * The existing strict option now consistently controls error short-circuiting during generation stages, affecting how strict mode surfaces errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->