### PR TITLE
fix: nested frag imports handled correctly

### DIFF
--- a/rust/shalom_dart_codegen/dart_tests/test/cross_dir_fragments/common_fragments/fragments.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/cross_dir_fragments/common_fragments/fragments.graphql
@@ -9,3 +9,11 @@ fragment PostFields on Post {
     title
     content
 }
+
+fragment AuthorFields on User {
+    ...UserFields
+    posts {
+        id
+        title
+    }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/cross_dir_fragments/nested_queries/operations.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/cross_dir_fragments/nested_queries/operations.graphql
@@ -1,0 +1,14 @@
+query GetAuthor($authorId: ID!) {
+    user(id: $authorId) {
+        ...AuthorFields
+    }
+}
+
+query GetPostWithAuthor($postId: ID!) {
+    post(id: $postId) {
+        ...PostFields
+        author {
+            ...AuthorFields
+        }
+    }
+}

--- a/rust/shalom_dart_codegen/templates/fragment.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/fragment.dart.jinja
@@ -14,16 +14,14 @@
 
 import "{{ schema_import_path }}";
 import 'package:shalom_core/shalom_core.dart';
+import 'package:collection/collection.dart';
 {% for import_alias, import_path in extra_imports | items -%}
 import '{{import_path}}' as {{import_alias}};
 {% endfor -%}
 
-{% if fragment.context.context.used_fragments | length > 0 -%}
-    // Fragment imports
-    {% for used_fragment in fragment.context.context.used_fragments -%}
-    import '{{used_fragment.name | lower}}.shalom.dart';
-    {% endfor %}
-{% endif %}
+{% for import_path in generate_fragment_imports(fragment_file_path, fragment.context.context.used_fragments) -%}
+import '{{ import_path }}';
+{% endfor %}
 
 // Generate abstract fragment class
 abstract class {{ fragment_name }} {

--- a/rust/shalom_dart_codegen/templates/operation.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation.dart.jinja
@@ -15,12 +15,10 @@ import '{{path}}' as {{ namespace_alias }};
 import 'package:shalom_core/shalom_core.dart';
 import 'package:collection/collection.dart';
 
-{% if operation.context.used_fragments | length > 0 %}
-    // Fragment imports
-    {% for used_fragment in operation.context.used_fragments -%}
-    import '{{ import_path_for_fragment_from_operation(operation.context.file_path, used_fragment.name) }}';
-    {% endfor -%}
-{% endif %}
+// Fragment imports
+{% for import_path in generate_fragment_imports(operation.context.file_path, operation.context.used_fragments) -%}
+import '{{ import_path }}';
+{% endfor -%}
 
 
 {% set operation_name = operation.context.operation_name %}


### PR DESCRIPTION
## Summary by Sourcery

Improve fragment import handling by introducing a recursive import generator, updating Jinja templates to leverage it, and adding comprehensive nested fragment tests

New Features:
- Support recursive nested fragment imports generation in codegen via the new generate_fragment_imports function

Bug Fixes:
- Fix nested fragment import resolution to correctly include all dependent fragments in generated Dart code

Enhancements:
- Refactor fragment.dart.jinja and operation.dart.jinja templates to use generate_fragment_imports and remove manual import loops
- Pass fragment file path into codegen context for accurate import path calculation

Tests:
- Add Dart tests for nested fragments including required, optional, cache normalization, equality, and serialization scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for nested and cross-directory GraphQL fragments with improved import resolution in code generation.

* **Tests**
  * Added comprehensive test suite validating nested fragment behavior, including serialization, equality checks, and cache normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->