### PR TITLE
add fetch policy on dart client

### DIFF
--- a/dart/shalom_core/lib/shalom_core.dart
+++ b/dart/shalom_core/lib/shalom_core.dart
@@ -15,7 +15,8 @@ export 'src/normelized_cache.dart'
 export 'src/shalom_ctx.dart' show RecordSubscriber, RefStreamType, ShalomCtx;
 export 'src/transport/http_link.dart'
     show HttpLink, HttpMethod, ShalomHttpTransport;
-export 'src/transport/link.dart' show GraphQLLink, ShalomClient, HeadersType;
+export 'src/transport/link.dart'
+    show GraphQLLink, ShalomClient, HeadersType, FetchPolicy;
 export 'src/transport/ws_link.dart' show WebSocketLink;
 export 'src/transport/ws_transport.dart' show WebSocketTransport, MessageSender;
 export 'src/transport/ws_messages.dart'


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable fetch policies for the Dart GraphQL client to control cache interaction during requests.

New Features:
- Add a FetchPolicy enum to configure network-only or network-first request behavior.
- Expose FetchPolicy through the public shalom_core export surface so it can be used by client code.

Enhancements:
- Extend ShalomClient.request to accept a fetchPolicy parameter and adjust cache subscription and update behavior accordingly when handling responses.