### PR TITLE
Promote shared interface fields to union base classes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -8,9 +8,9 @@ description: Use when building or modifying Dart/Flutter apps that use the Shalo
 Use this skill when acting as an app developer consuming Shalom. Prefer Shalom's generated Dart/Flutter APIs over hand-written GraphQL plumbing. Do not edit generated `__graphql__` files directly; change annotations/schema/config and regenerate.
 ## Paradigm
 shalom contains a "smart" runtime that automagically updates widgets if you use it correctly
-shalom is declerative meaning that as a rule of thumb we don't need services nor state management solutions for graphql stuff.
+shalom is declarative meaning that as a rule of thumb we don't need services nor state management solutions for graphql stuff.
 in shalom every widget should request only what it needs.
-in shalom we do less on the ui and more on the server. so if so far you have done sorting on the ui, you should (mostly) now delegate that to the server because usually list nodes would use fragments which are not readable (decleratively) by the list view builder.
+in shalom we do less on the ui and more on the server. so if so far you have done sorting on the ui, you should (mostly) now delegate that to the server because usually list nodes would use fragments which are not readable (declaratively) by the list view builder.
 if you still need to do sorting on the ui, make sure your lists are not huge an you'd prob better off without @Fragment widgets.
 
 

--- a/rust/shalom_core/src/operation/parse.rs
+++ b/rust/shalom_core/src/operation/parse.rs
@@ -296,7 +296,7 @@ where
 {
     trace!("Parsing union selection {:?}", union_type.name);
 
-    let obj_like = parse_obj_like_from_selection_set(
+    let mut obj_like = parse_obj_like_from_selection_set(
         ctx,
         global_ctx,
         path,
@@ -306,7 +306,35 @@ where
     let possible_concretes = global_ctx
         .schema_ctx
         .get_possible_concretes_for_union(&union_type);
-    // Determine if we need a fallback class
+
+    // An inline fragment type-conditioned on an interface that every member of this
+    // union implements applies unconditionally to the union field, regardless of
+    // which concrete member is actually returned. Promote its selections onto the
+    // union's own shared selections so the generated sealed base class exposes
+    // those fields directly instead of only on each concrete subclass.
+    let common_type_conds: Vec<String> = obj_like
+        .type_cond_selections
+        .keys()
+        .filter(|cond_typename| {
+            possible_concretes.iter().all(|concrete| {
+                global_ctx
+                    .schema_ctx
+                    .is_type_same_or_implementing_interface(concrete, cond_typename)
+            })
+        })
+        .cloned()
+        .collect();
+
+    for cond_typename in common_type_conds {
+        if let Some(cond_obj) = obj_like.type_cond_selections.get(&cond_typename) {
+            let selections = cond_obj.selections.clone();
+            let used_fragments = cond_obj.used_fragments.clone();
+            let used_inline_frags = cond_obj.used_inline_frags.clone();
+            obj_like.selections.extend(selections);
+            obj_like.used_fragments.extend(used_fragments);
+            obj_like.used_inline_frags.extend(used_inline_frags);
+        }
+    }
 
     UnionSelection::new(union_type, obj_like, is_optional, possible_concretes)
 }

--- a/rust/shalom_dart_codegen/dart_tests/test/union_common_interface/operations.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/union_common_interface/operations.graphql
@@ -1,0 +1,20 @@
+query GetErrorResult {
+  errorResult {
+    __typename
+    ... on ErrorInterface {
+      message
+    }
+  }
+}
+
+query GetMixedResult {
+  mixedResult {
+    __typename
+    ... on ErrorInterface {
+      message
+    }
+    ... on OtherThing {
+      value
+    }
+  }
+}

--- a/rust/shalom_dart_codegen/dart_tests/test/union_common_interface/schema.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/union_common_interface/schema.graphql
@@ -1,0 +1,23 @@
+type Query {
+  errorResult: ErrorUnion!
+  mixedResult: MixedUnion!
+}
+
+interface ErrorInterface {
+  message: String!
+}
+
+type DoesNotExistErr implements ErrorInterface {
+  message: String!
+}
+
+type AlreadyExistsErr implements ErrorInterface {
+  message: String!
+}
+
+type OtherThing {
+  value: Int!
+}
+
+union ErrorUnion = DoesNotExistErr | AlreadyExistsErr
+union MixedUnion = DoesNotExistErr | AlreadyExistsErr | OtherThing

--- a/rust/shalom_dart_codegen/dart_tests/test/union_common_interface/test.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/union_common_interface/test.dart
@@ -1,0 +1,68 @@
+import 'package:test/test.dart';
+import "__graphql__/GetErrorResult.shalom.dart";
+import "__graphql__/GetMixedResult.shalom.dart";
+
+void main() {
+  group('union with a common interface across every member', () {
+    test('sealed base class exposes the shared interface field directly', () {
+      final result = GetErrorResultResponse.fromJson({
+        "errorResult": {
+          "__typename": "DoesNotExistErr",
+          "message": "not found",
+        },
+      });
+
+      // No downcast required: `message` comes from ErrorInterface, which
+      // every member of ErrorUnion implements.
+      expect(result.errorResult.message, "not found");
+      expect(result.errorResult.$__typename, "DoesNotExistErr");
+    });
+
+    test('works the same for the other member of the union', () {
+      final result = GetErrorResultResponse.fromJson({
+        "errorResult": {
+          "__typename": "AlreadyExistsErr",
+          "message": "already there",
+        },
+      });
+
+      expect(result.errorResult.message, "already there");
+      expect(result.errorResult.$__typename, "AlreadyExistsErr");
+    });
+
+    test('roundtrips through toJson', () {
+      final data = {
+        "errorResult": {"__typename": "DoesNotExistErr", "message": "oops"},
+      };
+      final result = GetErrorResultResponse.fromJson(data);
+      expect(result.toJson(), data);
+    });
+  });
+
+  group('union with a partially-shared interface', () {
+    test(
+        'members implementing the interface still expose their field via downcast',
+        () {
+      final result = GetMixedResultResponse.fromJson({
+        "mixedResult": {
+          "__typename": "DoesNotExistErr",
+          "message": "not found",
+        },
+      });
+
+      final err =
+          result.mixedResult as GetMixedResult_mixedResult__DoesNotExistErr;
+      expect(err.message, "not found");
+    });
+
+    test('the member outside the shared interface keeps its own field', () {
+      final result = GetMixedResultResponse.fromJson({
+        "mixedResult": {"__typename": "OtherThing", "value": 42},
+      });
+
+      final other =
+          result.mixedResult as GetMixedResult_mixedResult__OtherThing;
+      expect(other.value, 42);
+    });
+  });
+}

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -610,7 +610,17 @@ where
         other_obj: &ObjectLikeCommon,
         global_ctx: &ShalomGlobalContext,
     ) {
+        // A union's own shared selections apply to every concrete member unconditionally,
+        // mirroring the runtime's `resolve_multitype_selections` (shalom_runtime/src/selection.rs).
+        let is_union_shared = matches!(
+            global_ctx
+                .schema_ctx
+                .get_type_strict(&other_obj.schema_typename),
+            GraphQLAny::Union(_)
+        );
+
         if resolve_to.schema_typename == other_obj.schema_typename
+            || is_union_shared
             || global_ctx.schema_ctx.is_type_implementing_interface(
                 &resolve_to.schema_typename,
                 &other_obj.schema_typename,

--- a/rust/shalom_dart_codegen/tests/usecases_test.rs
+++ b/rust/shalom_dart_codegen/tests/usecases_test.rs
@@ -62,6 +62,11 @@ fn test_interface_selection_dart() {
 }
 
 #[test]
+fn test_union_common_interface_dart() {
+    run_dart_tests_for_usecase("union_common_interface");
+}
+
+#[test]
 fn test_list_of_scalars_dart() {
     run_dart_tests_for_usecase("list_of_scalars");
 }

--- a/rust/shalom_runtime/src/selection.rs
+++ b/rust/shalom_runtime/src/selection.rs
@@ -49,8 +49,13 @@ pub fn resolve_multitype_selections(
             collect(root_type, &inline_frag.common, ctx, selections);
         }
 
-        if let Some(type_cond) = current_obj.type_cond_selections.get(root_type) {
-            collect(root_type, type_cond, ctx, selections);
+        for (cond_typename, type_cond) in current_obj.type_cond_selections.iter() {
+            if ctx
+                .schema_ctx
+                .is_type_same_or_implementing_interface(root_type, cond_typename)
+            {
+                collect(root_type, type_cond, ctx, selections);
+            }
         }
     }
 

--- a/rust/shalom_runtime/src/selection.rs
+++ b/rust/shalom_runtime/src/selection.rs
@@ -23,19 +23,36 @@ pub fn resolve_multitype_selections(
     ctx: &SharedShalomGlobalContext,
 ) -> Vec<FieldSelection> {
     let mut selections = HashSet::new();
+
+    /// Whether `root_type` satisfies a type condition named `cond_typename` -
+    /// either directly, via interface implementation, or by being a member of
+    /// a union named `cond_typename`.
+    fn type_condition_covers_root(
+        root_type: &str,
+        cond_typename: &str,
+        ctx: &SharedShalomGlobalContext,
+    ) -> bool {
+        if ctx
+            .schema_ctx
+            .is_type_same_or_implementing_interface(root_type, cond_typename)
+        {
+            return true;
+        }
+        matches!(
+            ctx.schema_ctx.get_type_strict(&cond_typename.to_string()),
+            shalom_core::schema::types::GraphQLAny::Union(union_type)
+                if union_type.members.contains(root_type)
+        )
+    }
+
     fn collect(
         root_type: &str,
         current_obj: &shalom_core::operation::types::ObjectLikeCommon,
         ctx: &SharedShalomGlobalContext,
         selections: &mut HashSet<FieldSelection>,
     ) {
-        let schema_type = ctx.schema_ctx.get_type_strict(&current_obj.schema_typename);
-        let include_shared = match schema_type {
-            shalom_core::schema::types::GraphQLAny::Union(_) => true,
-            _ => ctx
-                .schema_ctx
-                .is_type_same_or_implementing_interface(root_type, &current_obj.schema_typename),
-        };
+        let include_shared =
+            type_condition_covers_root(root_type, &current_obj.schema_typename, ctx);
         if include_shared {
             selections.extend(current_obj.selections.iter().cloned());
         }
@@ -50,10 +67,7 @@ pub fn resolve_multitype_selections(
         }
 
         for (cond_typename, type_cond) in current_obj.type_cond_selections.iter() {
-            if ctx
-                .schema_ctx
-                .is_type_same_or_implementing_interface(root_type, cond_typename)
-            {
+            if type_condition_covers_root(root_type, cond_typename, ctx) {
                 collect(root_type, type_cond, ctx, selections);
             }
         }

--- a/rust/shalom_runtime/tests/cache.rs
+++ b/rust/shalom_runtime/tests/cache.rs
@@ -586,6 +586,48 @@ mod unions {
         assert_eq!(search.get("__typename"), Some(&json!("Admin")));
         assert_eq!(search.get("level"), Some(&json!(7)));
     }
+
+    /// An inline fragment keyed by an interface shared by every union member must
+    /// still contribute its fields when resolving/reading each concrete member.
+    #[test]
+    fn test_interface_typed_inline_fragment_inside_union() {
+        let schema = r#"
+            interface ErrorInterface { id: ID!, message: String! }
+            type DoesNotExistErr implements ErrorInterface { id: ID!, message: String! }
+            type AlreadyExistsErr implements ErrorInterface { id: ID!, message: String! }
+            union MutationError = DoesNotExistErr | AlreadyExistsErr
+            type Query { search: MutationError }
+        "#;
+        let operation = r#"
+            query TestOp {
+                search {
+                    __typename
+                    ... on ErrorInterface { id message }
+                }
+            }
+        "#;
+        let (global_ctx, op_ctx) = build_ctx(schema, operation);
+
+        let result = normalize(
+            &global_ctx,
+            &op_ctx,
+            json!({ "search": { "__typename": "DoesNotExistErr", "id": "e1", "message": "not found" } }),
+            None,
+        );
+        assert!(result.used_refs.contains("ROOT_QUERY.search"));
+
+        let not_found = record(&global_ctx, "DoesNotExistErr:e1");
+        expect_scalar(&not_found, "message", json!("not found"));
+
+        normalize(
+            &global_ctx,
+            &op_ctx,
+            json!({ "search": { "__typename": "AlreadyExistsErr", "id": "e2", "message": "already there" } }),
+            None,
+        );
+        let already_exists = record(&global_ctx, "AlreadyExistsErr:e2");
+        expect_scalar(&already_exists, "message", json!("already there"));
+    }
 }
 
 mod interfaces {

--- a/rust/shalom_runtime/tests/cache.rs
+++ b/rust/shalom_runtime/tests/cache.rs
@@ -727,6 +727,43 @@ mod interfaces {
             .expect("node missing");
         assert_eq!(node.get("name"), Some(&json!("Grace")));
     }
+
+    /// An inline fragment keyed by a union name (rather than an interface) must
+    /// still recurse into its nested type conditions for members that belong to
+    /// that union, e.g. `... on Pet { ... on Cat { color } }` inside an
+    /// interface selection.
+    #[test]
+    fn test_nested_union_typed_inline_fragment() {
+        let schema = r#"
+            interface Node { id: ID! }
+            type Cat implements Node { id: ID!, color: String! }
+            type Dog implements Node { id: ID! }
+            union Pet = Cat | Dog
+            type Query { node: Node }
+        "#;
+        let operation = r#"
+            query TestOp {
+                node {
+                    __typename
+                    id
+                    ... on Pet {
+                        __typename
+                        ... on Cat { color }
+                    }
+                }
+            }
+        "#;
+        let (global_ctx, op_ctx) = build_ctx(schema, operation);
+        normalize(
+            &global_ctx,
+            &op_ctx,
+            json!({ "node": { "__typename": "Cat", "id": "c1", "color": "orange" } }),
+            None,
+        );
+
+        let cat = record(&global_ctx, "Cat:c1");
+        expect_scalar(&cat, "color", json!("orange"));
+    }
 }
 
 mod fragments {
@@ -1978,8 +2015,8 @@ mod fragment_subscriptions {
     #[test]
     fn test_updates_across_different_operations() {
         let schema = r#"
-            type Query { 
-                sharedValue: Int 
+            type Query {
+                sharedValue: Int
                 otherValue: String
             }
         "#;


### PR DESCRIPTION
Automatically flatten fields from inline fragments conditioned on interfaces that all union members implement. This allows these fields to be accessed directly on the generated sealed union class instead of requiring type-specific downcasts. Updates the runtime to correctly apply
these common selections during cache normalization.

## Summary by Sourcery

Promote fields selected via interface-typed inline fragments that are implemented by all union members to be shared selections on the union, and ensure both runtime resolution and Dart codegen treat these fields as directly accessible on the sealed union base type.

New Features:
- Allow union selections conditioned on a common interface implemented by every union member to be flattened onto the union’s shared selections so generated sealed union base classes expose those fields directly.

Bug Fixes:
- Ensure runtime multitype selection resolution applies interface-conditioned inline fragment selections to all compatible concrete types within a union.

Tests:
- Add Rust runtime tests and Dart integration tests covering unions whose members share an interface and partially share an interface, validating field accessibility and JSON roundtripping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of union selections so shared fields from common interfaces are available more consistently.
  * Added test coverage for unions that include interface-based fields and mixed union members.

* **Bug Fixes**
  * Fixed selection merging so fields shared across all union members can be accessed without extra downcasting.
  * Broadened runtime normalization to preserve interface-fragment fields for each concrete union member.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->