### PR TITLE
Implement selection merging for fragments and nested types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # shalom
 A GraphQL client runtime for Dart and Flutter.
 
-
-
 ### Installation
 
 1. Build the CLI from source:

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,13 +6,14 @@ description: Use when building or modifying Dart/Flutter apps that use the Shalo
 # Shalom
 
 Use this skill when acting as an app developer consuming Shalom. Prefer Shalom's generated Dart/Flutter APIs over hand-written GraphQL plumbing. Do not edit generated `__graphql__` files directly; change annotations/schema/config and regenerate.
+
 ## Paradigm
+
 shalom contains a "smart" runtime that automagically updates widgets if you use it correctly
 shalom is declarative meaning that as a rule of thumb we don't need services nor state management solutions for graphql stuff.
 in shalom every widget should request only what it needs.
 in shalom we do less on the ui and more on the server. so if so far you have done sorting on the ui, you should (mostly) now delegate that to the server because usually list nodes would use fragments which are not readable (declaratively) by the list view builder.
 if you still need to do sorting on the ui, make sure your lists are not huge an you'd prob better off without @Fragment widgets.
-
 
 ## Mental Model
 
@@ -143,7 +144,6 @@ The widget keeps an active observer for as long as it's in the tree, so GC won't
 
 `@Subscription` uses the same widget shape as `@Query`; the link must support streaming operation results.
 
-
 ## Naming Rules
 
 Shalom requires every generated GraphQL definition name to be globally unique across the app.
@@ -151,8 +151,8 @@ This includes: - `@Query` / `@Mutation` / `@Subscription` / `@Fragment` class na
 Do not reuse the same Dart class name for another Shalom operation or fragment, even if the GraphQL selection is different or lives in another file. Generated operation, fragment, data, variables, ref, and scope APIs are derived from these names, so duplicate names cause generation/runtime registration conflicts. Prefer explicit feature-prefixed names when needed.
 
 ## Imperative APIs In Flutter
-Imperative API's for reads are generally discouraged in Flutter, as they can lead to inconsistent state.
 
+Imperative API's for reads are generally discouraged in Flutter, as they can lead to inconsistent state.
 
 Default to declarative generated widgets/scopes for reads:
 
@@ -373,6 +373,8 @@ Fragment guidelines:
 - Fragment spreads are flattened into generated selections. If a fragment spreads another fragment, the generated concrete class implements the spread fragment interface.
 - Nested object selections inside fragments are generated in the fragment file.
 - Union/interface selections become sealed classes resolved by `__typename`.
+- If a fragment X is used by another fragment (Y) then fragment X classes would be `abstract` and only fragment X types would be concrete and can use `sealed` operator for multi-type(union/interface) handling.
+- Do not restructure GraphQL just to avoid overlapping nested fragment selections. Shalom should merge spread selections recursively, including nested union/interface variants; Dart errors such as `invalid_override` or sealed-class cross-library errors from valid fragment composition indicate a Shalom codegen bug.
 
 ## Optimistic Updates
 

--- a/rust/shalom_core/src/operation/parse.rs
+++ b/rust/shalom_core/src/operation/parse.rs
@@ -327,10 +327,11 @@ where
 
     for cond_typename in common_type_conds {
         if let Some(cond_obj) = obj_like.type_cond_selections.get(&cond_typename) {
-            let selections = cond_obj.selections.clone();
             let used_fragments = cond_obj.used_fragments.clone();
             let used_inline_frags = cond_obj.used_inline_frags.clone();
-            obj_like.selections.extend(selections);
+            for selection in cond_obj.selections.clone() {
+                obj_like.add_selection(selection);
+            }
             obj_like.used_fragments.extend(used_fragments);
             obj_like.used_inline_frags.extend(used_inline_frags);
         }

--- a/rust/shalom_core/src/operation/types.rs
+++ b/rust/shalom_core/src/operation/types.rs
@@ -148,6 +148,102 @@ impl FieldSelection {
     }
 }
 
+fn merge_selection_into_set(selections: &mut BTreeSet<FieldSelection>, selection: FieldSelection) {
+    if let Some(existing) = selections.take(&selection) {
+        selections.insert(merge_field_selection(existing, selection));
+    } else {
+        selections.insert(selection);
+    }
+}
+
+fn selection_kind_path_name(kind: &SelectionKind) -> Option<&str> {
+    match kind {
+        SelectionKind::Object(selection) => Some(&selection.common.path_name),
+        SelectionKind::Union(selection) => Some(&selection.common.common.path_name),
+        SelectionKind::Interface(selection) => Some(&selection.common.common.path_name),
+        SelectionKind::List(selection) => selection_kind_path_name(&selection.of_kind),
+        _ => None,
+    }
+}
+
+fn selection_is_owned_by_path(selection: &FieldSelection, owner_path: &str) -> bool {
+    selection_kind_path_name(&selection.kind)
+        .is_some_and(|path| path.starts_with(&format!("{owner_path}_")))
+}
+
+fn merge_fragment_selection_into_set(
+    selections: &mut BTreeSet<FieldSelection>,
+    owner_path: &str,
+    selection: FieldSelection,
+) {
+    if let Some(existing) = selections.take(&selection) {
+        if selection_is_owned_by_path(&existing, owner_path) {
+            selections.insert(merge_field_selection(existing, selection));
+        } else {
+            selections.insert(merge_field_selection(selection, existing));
+        }
+    } else {
+        selections.insert(selection);
+    }
+}
+
+fn merge_field_selection(existing: FieldSelection, incoming: FieldSelection) -> FieldSelection {
+    let kind = merge_selection_kind(&existing.kind, &incoming.kind)
+        .unwrap_or_else(|| existing.kind.clone());
+
+    FieldSelection {
+        selection_common: existing.selection_common,
+        kind,
+        arguments: existing.arguments,
+    }
+}
+
+fn merge_selection_kind(
+    existing: &SelectionKind,
+    incoming: &SelectionKind,
+) -> Option<SelectionKind> {
+    match (existing, incoming) {
+        (SelectionKind::Object(existing), SelectionKind::Object(incoming)) => {
+            let mut common = existing.common.clone();
+            common.merge(incoming.common.clone());
+            Some(SelectionKind::Object(ObjectSelection::new(
+                existing.is_optional,
+                common,
+            )))
+        }
+        (SelectionKind::Union(existing), SelectionKind::Union(incoming)) => {
+            let mut common = existing.common.common.clone();
+            common.merge(incoming.common.common.clone());
+            let mut possible_concrete_types = existing.common.possible_concrete_types.clone();
+            possible_concrete_types.extend(incoming.common.possible_concrete_types.clone());
+            Some(SelectionKind::Union(UnionSelection::new(
+                existing.union_type.clone(),
+                common,
+                existing.common.is_optional,
+                possible_concrete_types,
+            )))
+        }
+        (SelectionKind::Interface(existing), SelectionKind::Interface(incoming)) => {
+            let mut common = existing.common.common.clone();
+            common.merge(incoming.common.common.clone());
+            let mut possible_concrete_types = existing.common.possible_concrete_types.clone();
+            possible_concrete_types.extend(incoming.common.possible_concrete_types.clone());
+            Some(SelectionKind::Interface(InterfaceSelection::new(
+                existing.interface_type.clone(),
+                common,
+                existing.common.is_optional,
+                possible_concrete_types,
+            )))
+        }
+        (SelectionKind::List(existing), SelectionKind::List(incoming)) => {
+            let of_kind = merge_selection_kind(&existing.of_kind, &incoming.of_kind)
+                .unwrap_or_else(|| existing.of_kind.clone());
+            Some(SelectionKind::new_list(existing.is_optional, of_kind))
+        }
+        _ => None,
+    }
+}
+
 pub type SharedSelection = Rc<FieldSelection>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -229,7 +325,12 @@ impl ObjectLikeCommon {
             // the same type just extend selections (HashSet handles deduplication)
             self.used_fragments.extend(other.used_fragments);
             self.used_inline_frags.extend(other.used_inline_frags);
-            self.selections.extend(other.selections);
+            for selection in other.selections {
+                self.add_selection(selection);
+            }
+            for (_, type_cond_selection) in other.type_cond_selections {
+                self.merge(type_cond_selection);
+            }
         } else {
             // different type - store as type condition, merge if already exists
             if let Some(existing) = self.type_cond_selections.get_mut(&other.schema_typename) {
@@ -242,8 +343,12 @@ impl ObjectLikeCommon {
     }
 
     pub fn add_selection(&mut self, selection: FieldSelection) {
-        // HashSet automatically handles deduplication based on Hash/Eq implementation
-        self.selections.insert(selection);
+        if let Some(existing) = self.selections.take(&selection) {
+            self.selections
+                .insert(merge_field_selection(existing, selection));
+        } else {
+            self.selections.insert(selection);
+        }
     }
     /// finds a field with a name
     pub fn contains_field(&self, name: &str) -> bool {
@@ -327,13 +432,19 @@ impl ObjectLikeCommon {
 
         for frag_name in &self.used_fragments {
             let fragment = ctx.get_fragment_strict(frag_name);
-            selections.extend(fragment.get_on_type().get_all_selections_distinct(ctx));
+            for selection in fragment.get_on_type().get_all_selections_distinct(ctx) {
+                merge_fragment_selection_into_set(&mut selections, &self.path_name, selection);
+            }
         }
         for inline_frag in self.used_inline_frags.values() {
-            selections.extend(inline_frag.common.get_all_selections_distinct(ctx));
+            for selection in inline_frag.common.get_all_selections_distinct(ctx) {
+                merge_fragment_selection_into_set(&mut selections, &self.path_name, selection);
+            }
         }
         for obj in self.type_cond_selections.values() {
-            selections.extend(obj.get_all_selections_distinct(ctx));
+            for selection in obj.get_all_selections_distinct(ctx) {
+                merge_fragment_selection_into_set(&mut selections, &self.path_name, selection);
+            }
         }
         selections
     }
@@ -352,7 +463,9 @@ impl ObjectLikeCommon {
                 root_type_name,
                 &current_obj.schema_typename,
             ) {
-                resolved_selections.extend(current_obj.selections.iter().cloned());
+                for selection in current_obj.selections.iter().cloned() {
+                    merge_selection_into_set(resolved_selections, selection);
+                }
             }
 
             // used frags are directly on this type
@@ -363,7 +476,13 @@ impl ObjectLikeCommon {
                     root_type_name,
                     &frag_root.schema_typename,
                 ) {
-                    resolved_selections.extend(frag_root.selections.iter().cloned());
+                    for selection in frag_root.selections.iter().cloned() {
+                        merge_fragment_selection_into_set(
+                            resolved_selections,
+                            &current_obj.path_name,
+                            selection,
+                        );
+                    }
                     recursive_inner(root_type_name, resolved_selections, frag_root, ctx);
                 }
             }
@@ -374,7 +493,13 @@ impl ObjectLikeCommon {
                     .schema_ctx
                     .is_type_same_or_implementing_interface(root_type_name, on_type)
                 {
-                    resolved_selections.extend(inline_frag.common.selections.iter().cloned());
+                    for selection in inline_frag.common.selections.iter().cloned() {
+                        merge_fragment_selection_into_set(
+                            resolved_selections,
+                            &current_obj.path_name,
+                            selection,
+                        );
+                    }
                     recursive_inner(
                         root_type_name,
                         resolved_selections,

--- a/rust/shalom_core/src/operation/types.rs
+++ b/rust/shalom_core/src/operation/types.rs
@@ -148,7 +148,10 @@ impl FieldSelection {
     }
 }
 
-fn merge_selection_into_set(selections: &mut BTreeSet<FieldSelection>, selection: FieldSelection) {
+pub fn merge_selection_into_set(
+    selections: &mut BTreeSet<FieldSelection>,
+    selection: FieldSelection,
+) {
     if let Some(existing) = selections.take(&selection) {
         selections.insert(merge_field_selection(existing, selection));
     } else {

--- a/rust/shalom_dart_codegen/dart_tests/test/fragment_inherited_interface_fields/operations.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/fragment_inherited_interface_fields/operations.graphql
@@ -21,6 +21,51 @@ fragment ElephantWithToysFrag on Elephant {
   trunkLength
 }
 
+fragment MinimalAnimalNestedFrag on Elephant {
+  favoriteToy {
+    id
+  }
+  status {
+    __typename
+    ... on MovementStatus {
+      motionType
+      channelAlert {
+        __typename
+      }
+    }
+  }
+}
+
+fragment MileSightChannelAlertFrag on ChannelAlertInterface {
+  __typename
+  channelName
+  ... on MileSightChannelAlert {
+    confidence
+  }
+}
+
+fragment MovementStatusWithChannelAlertFrag on MovementStatus {
+  channelAlert {
+    ...MileSightChannelAlertFrag
+  }
+}
+
+fragment ExtendedAnimalNestedFrag on Elephant {
+  ...MinimalAnimalNestedFrag
+  favoriteToy {
+    label
+  }
+  status {
+    ... on StatusInterface {
+      originMessage
+    }
+    ... on MovementStatus {
+      sensitivity
+      ...MovementStatusWithChannelAlertFrag
+    }
+  }
+}
+
 fragment AnimalWithToysGlobalFrag on Animal {
   __typename
   ...AnimalWithToysFrag
@@ -30,5 +75,12 @@ fragment AnimalWithToysGlobalFrag on Animal {
 query ZooAnimalsQuery {
   animals {
     ...AnimalWithToysGlobalFrag
+  }
+}
+
+query ElephantNestedQuery {
+  animals {
+    __typename
+    ...ExtendedAnimalNestedFrag
   }
 }

--- a/rust/shalom_dart_codegen/dart_tests/test/fragment_inherited_interface_fields/schema.graphql
+++ b/rust/shalom_dart_codegen/dart_tests/test/fragment_inherited_interface_fields/schema.graphql
@@ -7,6 +7,8 @@ interface Animal {
   name: String!
   species: String!
   toys: [Toy!]!
+  favoriteToy: Toy!
+  status: AnimalStatus!
 }
 
 type Toy {
@@ -14,11 +16,40 @@ type Toy {
   label: String!
 }
 
+interface StatusInterface {
+  originMessage: String!
+}
+
+interface ChannelAlertInterface {
+  channelName: String!
+}
+
+type MileSightChannelAlert implements ChannelAlertInterface {
+  channelName: String!
+  confidence: Int!
+}
+
+type MovementStatus implements StatusInterface {
+  originMessage: String!
+  motionType: String!
+  sensitivity: Int!
+  channelAlert: ChannelAlertInterface!
+}
+
+type IdleStatus implements StatusInterface {
+  originMessage: String!
+  idleSince: String!
+}
+
+union AnimalStatus = MovementStatus | IdleStatus
+
 type Monkey implements Animal {
   id: ID!
   name: String!
   species: String!
   toys: [Toy!]!
+  favoriteToy: Toy!
+  status: AnimalStatus!
   bananaCount: Int!
 }
 
@@ -27,5 +58,7 @@ type Elephant implements Animal {
   name: String!
   species: String!
   toys: [Toy!]!
+  favoriteToy: Toy!
+  status: AnimalStatus!
   trunkLength: Int!
 }

--- a/rust/shalom_dart_codegen/dart_tests/test/fragment_inherited_interface_fields/test.dart
+++ b/rust/shalom_dart_codegen/dart_tests/test/fragment_inherited_interface_fields/test.dart
@@ -1,6 +1,10 @@
 import 'package:test/test.dart';
 
 import '__graphql__/ElephantWithToysFrag.shalom.dart';
+import '__graphql__/ExtendedAnimalNestedFrag.shalom.dart';
+import '__graphql__/MileSightChannelAlertFrag.shalom.dart';
+import '__graphql__/MinimalAnimalNestedFrag.shalom.dart';
+import '__graphql__/MovementStatusWithChannelAlertFrag.shalom.dart';
 
 void main() {
   test(
@@ -21,5 +25,44 @@ void main() {
     expect(data.species, 'elephant');
     expect(data.trunkLength, 7);
     expect(data.toys.single.label, 'Ball');
+  });
+
+  test(
+      'fragment spreading another fragment merges matching nested object and union fields',
+      () {
+    final data = ExtendedAnimalNestedFragImpl.fromJson({
+      'id': 'elephant-1',
+      'favoriteToy': {'id': 'toy-1', 'label': 'Ball'},
+      'status': {
+        '__typename': 'MovementStatus',
+        'originMessage': 'camera-1',
+        'motionType': 'person',
+        'sensitivity': 8,
+        'channelAlert': {
+          '__typename': 'MileSightChannelAlert',
+          'channelName': 'north gate',
+          'confidence': 91,
+        },
+      },
+    });
+
+    final MinimalAnimalNestedFrag minimal = data;
+    expect(minimal.favoriteToy.id, 'toy-1');
+    expect(data.favoriteToy.label, 'Ball');
+
+    final status =
+        minimal.status as ExtendedAnimalNestedFrag_status__MovementStatus;
+    expect(status.motionType, 'person');
+    expect(status.originMessage, 'camera-1');
+    expect(status.sensitivity, 8);
+
+    final MileSightChannelAlertFrag channelAlert = status.channelAlert;
+    expect(channelAlert.channelName, 'north gate');
+    expect(
+      (channelAlert
+              as MovementStatusWithChannelAlertFrag_channelAlert__MileSightChannelAlert)
+          .confidence,
+      91,
+    );
   });
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/graphql/__graphql__/shalom_init.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/graphql/__graphql__/shalom_init.shalom.dart
@@ -53,6 +53,23 @@ interface HasFavoriteToy {
   favoriteToy: Toy!
 }
 
+interface StatusInterface {
+  originMessage: String!
+}
+
+type MovementStatus implements StatusInterface {
+  originMessage: String!
+  motionType: String!
+  sensitivity: Int!
+}
+
+type IdleStatus implements StatusInterface {
+  originMessage: String!
+  idleSince: String!
+}
+
+union AnimalStatus = MovementStatus | IdleStatus
+
 type Toy {
   id: ID!
   label: String!
@@ -69,6 +86,7 @@ type Dog implements Animal & HasFavoriteToy {
   breed: String!
   owner: Owner
   favoriteToy: Toy!
+  status: AnimalStatus!
 }
 
 type Cat implements Animal {
@@ -180,6 +198,33 @@ fragment DogWithFavoriteToyFrag on Dog @observe {
   );
   client.registerFragment(
     document: r'''
+fragment MinimalDogStatusFrag on Dog @observe {
+  status {
+    __typename
+    ... on MovementStatus {
+      motionType
+    }
+  }
+}
+''',
+  );
+  client.registerFragment(
+    document: r'''
+fragment ExtendedDogStatusFrag on Dog @observe {
+  ...MinimalDogStatusFrag
+  status {
+    ... on StatusInterface {
+      originMessage
+    }
+    ... on MovementStatus {
+      sensitivity
+    }
+  }
+}
+''',
+  );
+  client.registerFragment(
+    document: r'''
 fragment DogFrag on Dog @observe {
   name
   breed
@@ -269,6 +314,7 @@ query ZooAnimalsContractQuery @observe {
     ...CommonAnimalFrag
     ...DogFavoriteFrag
     ...DogWithFavoriteToyFrag
+    ...ExtendedDogStatusFrag
   }
 }
 ''',

--- a/rust/shalom_dart_codegen/flutter_tests/lib/graphql/schema.graphql
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/graphql/schema.graphql
@@ -42,6 +42,23 @@ interface HasFavoriteToy {
   favoriteToy: Toy!
 }
 
+interface StatusInterface {
+  originMessage: String!
+}
+
+type MovementStatus implements StatusInterface {
+  originMessage: String!
+  motionType: String!
+  sensitivity: Int!
+}
+
+type IdleStatus implements StatusInterface {
+  originMessage: String!
+  idleSince: String!
+}
+
+union AnimalStatus = MovementStatus | IdleStatus
+
 type Toy {
   id: ID!
   label: String!
@@ -58,6 +75,7 @@ type Dog implements Animal & HasFavoriteToy {
   breed: String!
   owner: Owner
   favoriteToy: Toy!
+  status: AnimalStatus!
 }
 
 type Cat implements Animal {

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ExtendedDogStatusFrag.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ExtendedDogStatusFrag.shalom.dart
@@ -91,7 +91,8 @@ sealed class ExtendedDogStatusFrag_status
 }
 
 final class ExtendedDogStatusFrag_status__IdleStatus
-    extends ExtendedDogStatusFrag_status {
+    extends ExtendedDogStatusFrag_status
+    implements MinimalDogStatusFrag_status__IdleStatus {
   static String G__typename = "IdleStatus";
 
   /// class members
@@ -137,7 +138,8 @@ final class ExtendedDogStatusFrag_status__IdleStatus
 }
 
 final class ExtendedDogStatusFrag_status__MovementStatus
-    extends ExtendedDogStatusFrag_status {
+    extends ExtendedDogStatusFrag_status
+    implements MinimalDogStatusFrag_status__MovementStatus {
   static String G__typename = "MovementStatus";
 
   /// class members

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ExtendedDogStatusFrag.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ExtendedDogStatusFrag.shalom.dart
@@ -1,0 +1,300 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers, unnecessary_cast, camel_case_extensions
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// Fragment: ExtendedDogStatusFrag
+
+import "../../graphql/__graphql__/schema.shalom.dart";
+import 'package:shalom/shalom.dart' as shalom_core;
+import 'package:collection/collection.dart';
+
+import 'MinimalDogStatusFrag.shalom.dart';
+
+import 'dart:async' show Stream;
+import 'package:flutter/widgets.dart';
+import 'package:shalom_flutter/shalom_flutter.dart';
+
+// ------------ fragment widget API -------------
+
+extension type ExtendedDogStatusFragRef.fromInput(
+  shalom_core.ObservedRefInput _inner
+) {
+  static const String fragmentName = 'ExtendedDogStatusFrag';
+
+  static ExtendedDogStatusFragRef fromEntityKey(String entityKey) {
+    return ExtendedDogStatusFragRef.fromInput(
+      shalom_core.ObservedRefInput(
+        observableId: fragmentName,
+        anchor: entityKey,
+      ),
+    );
+  }
+
+  static ExtendedDogStatusFragRef fromId(String id) =>
+      fromEntityKey(ExtendedDogStatusFragData.entityKey(id));
+
+  shalom_core.ObservedRefInput get toInput => _inner;
+  String get anchor => _inner.anchor;
+  shalom_core.JsonObject toJson() => {
+    '__shalom_observed_ref': {
+      'observable_id': _inner.observableId,
+      'anchor': _inner.anchor,
+    },
+  };
+
+  /// Reads the entity this ref points to through [cache], decoding it as
+  /// [ExtendedDogStatusFragData]. Returns `null` when absent or incomplete.
+  ExtendedDogStatusFragData? readFrom(shalom_core.CacheProxy cache) {
+    return cache.readFragment<ExtendedDogStatusFragData>(
+      fragmentName: fragmentName,
+      entityKey: anchor,
+      decoder: ExtendedDogStatusFragData.fromCache,
+    );
+  }
+
+  Stream<shalom_core.GraphQLResponse<ExtendedDogStatusFragData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) {
+    return client.subscribeToFragment<ExtendedDogStatusFragData>(
+      ref: _inner,
+      decoder: ExtendedDogStatusFragData.fromCache,
+    );
+  }
+}
+
+abstract class ExtendedDogStatusFrag implements MinimalDogStatusFrag {
+  String get id;
+  ExtendedDogStatusFrag_status get status;
+
+  shalom_core.JsonObject toJson();
+}
+
+sealed class ExtendedDogStatusFrag_status
+    implements MinimalDogStatusFrag_status {
+  String get originMessage;
+
+  String get $__typename;
+  const ExtendedDogStatusFrag_status();
+
+  shalom_core.JsonObject toJson();
+
+  static ExtendedDogStatusFrag_status fromJson(shalom_core.JsonObject data) {
+    final typename = data['__typename'] as String;
+    switch (typename) {
+      case 'IdleStatus':
+        return ExtendedDogStatusFrag_status__IdleStatus.fromJson(data);
+      case 'MovementStatus':
+        return ExtendedDogStatusFrag_status__MovementStatus.fromJson(data);
+
+      default:
+        throw Exception("Unknown typename $typename");
+    }
+  }
+}
+
+final class ExtendedDogStatusFrag_status__IdleStatus
+    extends ExtendedDogStatusFrag_status {
+  static String G__typename = "IdleStatus";
+
+  /// class members
+
+  final String originMessage;
+
+  // Getter for typename (public accessor for static __typename field)
+  String get $__typename => G__typename;
+
+  // keywordargs constructor
+  const ExtendedDogStatusFrag_status__IdleStatus({required this.originMessage});
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is ExtendedDogStatusFrag_status__IdleStatus &&
+            originMessage == other.originMessage);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    originMessage,
+
+    ExtendedDogStatusFrag_status__IdleStatus.G__typename,
+  ]);
+
+  shalom_core.JsonObject toJson() {
+    return {
+      "__typename": ExtendedDogStatusFrag_status__IdleStatus.G__typename,
+
+      'originMessage': this.originMessage,
+    };
+  }
+
+  static ExtendedDogStatusFrag_status__IdleStatus fromJson(
+    shalom_core.JsonObject data,
+  ) {
+    final String originMessage$value = data['originMessage'] as String;
+    return ExtendedDogStatusFrag_status__IdleStatus(
+      originMessage: originMessage$value,
+    );
+  }
+}
+
+final class ExtendedDogStatusFrag_status__MovementStatus
+    extends ExtendedDogStatusFrag_status {
+  static String G__typename = "MovementStatus";
+
+  /// class members
+
+  final String motionType;
+
+  final String originMessage;
+
+  final int sensitivity;
+
+  // Getter for typename (public accessor for static __typename field)
+  String get $__typename => G__typename;
+
+  // keywordargs constructor
+  const ExtendedDogStatusFrag_status__MovementStatus({
+    required this.motionType,
+
+    required this.originMessage,
+
+    required this.sensitivity,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is ExtendedDogStatusFrag_status__MovementStatus &&
+            motionType == other.motionType &&
+            originMessage == other.originMessage &&
+            sensitivity == other.sensitivity);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    motionType,
+
+    originMessage,
+
+    sensitivity,
+
+    ExtendedDogStatusFrag_status__MovementStatus.G__typename,
+  ]);
+
+  shalom_core.JsonObject toJson() {
+    return {
+      "__typename": ExtendedDogStatusFrag_status__MovementStatus.G__typename,
+
+      'motionType': this.motionType,
+
+      'originMessage': this.originMessage,
+
+      'sensitivity': this.sensitivity,
+    };
+  }
+
+  static ExtendedDogStatusFrag_status__MovementStatus fromJson(
+    shalom_core.JsonObject data,
+  ) {
+    final String motionType$value = data['motionType'] as String;
+    final String originMessage$value = data['originMessage'] as String;
+    final int sensitivity$value = data['sensitivity'] as int;
+    return ExtendedDogStatusFrag_status__MovementStatus(
+      motionType: motionType$value,
+
+      originMessage: originMessage$value,
+
+      sensitivity: sensitivity$value,
+    );
+  }
+}
+
+final class ExtendedDogStatusFragData
+    implements ExtendedDogStatusFrag, shalom_core.FragmentInterface {
+  final String id;
+  final ExtendedDogStatusFrag_status status;
+
+  const ExtendedDogStatusFragData({required this.id, required this.status});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ExtendedDogStatusFragData &&
+          id == other.id &&
+          status == other.status);
+
+  @override
+  int get hashCode => Object.hashAll([id, status]);
+
+  @override
+  String fragment$Name() => 'ExtendedDogStatusFrag';
+
+  @override
+  String entity$Type() => 'Dog';
+
+  @override
+  String entity$Id() => this.id;
+
+  /// The normalized cache key for the entity identified by [id], e.g.
+  /// `'Dog:123'`.
+  static String entityKey(String id) => 'Dog:$id';
+
+  static ExtendedDogStatusFragData fromCache(shalom_core.JsonObject data) {
+    final String id$value = data['id'] as String;
+    final ExtendedDogStatusFrag_status status$value =
+        ExtendedDogStatusFrag_status.fromJson(
+          data['status'] as shalom_core.JsonObject,
+        );
+    return ExtendedDogStatusFragData(id: id$value, status: status$value);
+  }
+
+  shalom_core.JsonObject toJson() {
+    return {'id': this.id, 'status': this.status.toJson()};
+  }
+}
+
+abstract class $ExtendedDogStatusFrag extends StatelessWidget {
+  final ExtendedDogStatusFragRef ref;
+  const $ExtendedDogStatusFrag({super.key, required this.ref});
+
+  Widget buildData(BuildContext context, ExtendedDogStatusFragData data);
+  Widget buildLoading(BuildContext context) => const SizedBox.shrink();
+  Widget buildError(BuildContext context, Object error) => ErrorWidget(error);
+
+  @override
+  Widget build(BuildContext context) {
+    return ExtendedDogStatusFragScope(
+      ref: ref,
+      loadingBuilder: buildLoading,
+      errorBuilder: buildError,
+      builder: buildData,
+    );
+  }
+}
+
+class ExtendedDogStatusFragScope extends StatelessWidget {
+  final ExtendedDogStatusFragRef ref;
+  final ShalomDataWidgetBuilder<ExtendedDogStatusFragData> builder;
+  final WidgetBuilder? loadingBuilder;
+  final ShalomErrorBuilder? errorBuilder;
+
+  const ExtendedDogStatusFragScope({
+    super.key,
+    required this.ref,
+    required this.builder,
+    this.loadingBuilder,
+    this.errorBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ShalomDataScope<ExtendedDogStatusFragData>(
+      identity: ref.toInput,
+      observe: (client) => ref.observe(client),
+      loadingBuilder: loadingBuilder,
+      errorBuilder: errorBuilder,
+      builder: builder,
+    );
+  }
+}
+
+// ------------ END fragment widget API -------------

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart
@@ -1,0 +1,256 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names, unused_import, camel_case_types, unnecessary_this, unnecessary_non_null_assertion, depend_on_referenced_packages, empty_statements, annotate_overrides, no_leading_underscores_for_local_identifiers, unnecessary_cast, camel_case_extensions
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// Fragment: MinimalDogStatusFrag
+
+import "../../graphql/__graphql__/schema.shalom.dart";
+import 'package:shalom/shalom.dart' as shalom_core;
+import 'package:collection/collection.dart';
+
+import 'dart:async' show Stream;
+import 'package:flutter/widgets.dart';
+import 'package:shalom_flutter/shalom_flutter.dart';
+
+// ------------ fragment widget API -------------
+
+extension type MinimalDogStatusFragRef.fromInput(
+  shalom_core.ObservedRefInput _inner
+) {
+  static const String fragmentName = 'MinimalDogStatusFrag';
+
+  static MinimalDogStatusFragRef fromEntityKey(String entityKey) {
+    return MinimalDogStatusFragRef.fromInput(
+      shalom_core.ObservedRefInput(
+        observableId: fragmentName,
+        anchor: entityKey,
+      ),
+    );
+  }
+
+  static MinimalDogStatusFragRef fromId(String id) =>
+      fromEntityKey(MinimalDogStatusFragData.entityKey(id));
+
+  shalom_core.ObservedRefInput get toInput => _inner;
+  String get anchor => _inner.anchor;
+  shalom_core.JsonObject toJson() => {
+    '__shalom_observed_ref': {
+      'observable_id': _inner.observableId,
+      'anchor': _inner.anchor,
+    },
+  };
+
+  /// Reads the entity this ref points to through [cache], decoding it as
+  /// [MinimalDogStatusFragData]. Returns `null` when absent or incomplete.
+  MinimalDogStatusFragData? readFrom(shalom_core.CacheProxy cache) {
+    return cache.readFragment<MinimalDogStatusFragData>(
+      fragmentName: fragmentName,
+      entityKey: anchor,
+      decoder: MinimalDogStatusFragData.fromCache,
+    );
+  }
+
+  Stream<shalom_core.GraphQLResponse<MinimalDogStatusFragData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) {
+    return client.subscribeToFragment<MinimalDogStatusFragData>(
+      ref: _inner,
+      decoder: MinimalDogStatusFragData.fromCache,
+    );
+  }
+}
+
+abstract class MinimalDogStatusFrag {
+  String get id;
+  MinimalDogStatusFrag_status get status;
+
+  shalom_core.JsonObject toJson();
+}
+
+abstract class MinimalDogStatusFrag_status {
+  String get $__typename;
+  const MinimalDogStatusFrag_status();
+
+  shalom_core.JsonObject toJson();
+
+  static MinimalDogStatusFrag_status fromJson(shalom_core.JsonObject data) {
+    final typename = data['__typename'] as String;
+    switch (typename) {
+      case 'IdleStatus':
+        return MinimalDogStatusFrag_status__IdleStatus.fromJson(data);
+      case 'MovementStatus':
+        return MinimalDogStatusFrag_status__MovementStatus.fromJson(data);
+
+      default:
+        throw Exception("Unknown typename $typename");
+    }
+  }
+}
+
+final class MinimalDogStatusFrag_status__IdleStatus
+    extends MinimalDogStatusFrag_status {
+  static String G__typename = "IdleStatus";
+
+  /// class members
+
+  // Getter for typename (public accessor for static __typename field)
+  String get $__typename => G__typename;
+
+  // keywordargs constructor
+  const MinimalDogStatusFrag_status__IdleStatus();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is MinimalDogStatusFrag_status__IdleStatus);
+  }
+
+  @override
+  int get hashCode =>
+      Object.hashAll([MinimalDogStatusFrag_status__IdleStatus.G__typename]);
+
+  shalom_core.JsonObject toJson() {
+    return {"__typename": MinimalDogStatusFrag_status__IdleStatus.G__typename};
+  }
+
+  static MinimalDogStatusFrag_status__IdleStatus fromJson(
+    shalom_core.JsonObject data,
+  ) {
+    return MinimalDogStatusFrag_status__IdleStatus();
+  }
+}
+
+final class MinimalDogStatusFrag_status__MovementStatus
+    extends MinimalDogStatusFrag_status {
+  static String G__typename = "MovementStatus";
+
+  /// class members
+
+  final String motionType;
+
+  // Getter for typename (public accessor for static __typename field)
+  String get $__typename => G__typename;
+
+  // keywordargs constructor
+  const MinimalDogStatusFrag_status__MovementStatus({required this.motionType});
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other is MinimalDogStatusFrag_status__MovementStatus &&
+            motionType == other.motionType);
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    motionType,
+
+    MinimalDogStatusFrag_status__MovementStatus.G__typename,
+  ]);
+
+  shalom_core.JsonObject toJson() {
+    return {
+      "__typename": MinimalDogStatusFrag_status__MovementStatus.G__typename,
+
+      'motionType': this.motionType,
+    };
+  }
+
+  static MinimalDogStatusFrag_status__MovementStatus fromJson(
+    shalom_core.JsonObject data,
+  ) {
+    final String motionType$value = data['motionType'] as String;
+    return MinimalDogStatusFrag_status__MovementStatus(
+      motionType: motionType$value,
+    );
+  }
+}
+
+final class MinimalDogStatusFragData
+    implements MinimalDogStatusFrag, shalom_core.FragmentInterface {
+  final String id;
+  final MinimalDogStatusFrag_status status;
+
+  const MinimalDogStatusFragData({required this.id, required this.status});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MinimalDogStatusFragData &&
+          id == other.id &&
+          status == other.status);
+
+  @override
+  int get hashCode => Object.hashAll([id, status]);
+
+  @override
+  String fragment$Name() => 'MinimalDogStatusFrag';
+
+  @override
+  String entity$Type() => 'Dog';
+
+  @override
+  String entity$Id() => this.id;
+
+  /// The normalized cache key for the entity identified by [id], e.g.
+  /// `'Dog:123'`.
+  static String entityKey(String id) => 'Dog:$id';
+
+  static MinimalDogStatusFragData fromCache(shalom_core.JsonObject data) {
+    final String id$value = data['id'] as String;
+    final MinimalDogStatusFrag_status status$value =
+        MinimalDogStatusFrag_status.fromJson(
+          data['status'] as shalom_core.JsonObject,
+        );
+    return MinimalDogStatusFragData(id: id$value, status: status$value);
+  }
+
+  shalom_core.JsonObject toJson() {
+    return {'id': this.id, 'status': this.status.toJson()};
+  }
+}
+
+abstract class $MinimalDogStatusFrag extends StatelessWidget {
+  final MinimalDogStatusFragRef ref;
+  const $MinimalDogStatusFrag({super.key, required this.ref});
+
+  Widget buildData(BuildContext context, MinimalDogStatusFragData data);
+  Widget buildLoading(BuildContext context) => const SizedBox.shrink();
+  Widget buildError(BuildContext context, Object error) => ErrorWidget(error);
+
+  @override
+  Widget build(BuildContext context) {
+    return MinimalDogStatusFragScope(
+      ref: ref,
+      loadingBuilder: buildLoading,
+      errorBuilder: buildError,
+      builder: buildData,
+    );
+  }
+}
+
+class MinimalDogStatusFragScope extends StatelessWidget {
+  final MinimalDogStatusFragRef ref;
+  final ShalomDataWidgetBuilder<MinimalDogStatusFragData> builder;
+  final WidgetBuilder? loadingBuilder;
+  final ShalomErrorBuilder? errorBuilder;
+
+  const MinimalDogStatusFragScope({
+    super.key,
+    required this.ref,
+    required this.builder,
+    this.loadingBuilder,
+    this.errorBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ShalomDataScope<MinimalDogStatusFragData>(
+      identity: ref.toInput,
+      observe: (client) => ref.observe(client),
+      loadingBuilder: loadingBuilder,
+      errorBuilder: errorBuilder,
+      builder: builder,
+    );
+  }
+}
+
+// ------------ END fragment widget API -------------

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart
@@ -85,7 +85,7 @@ abstract class MinimalDogStatusFrag_status {
   }
 }
 
-final class MinimalDogStatusFrag_status__IdleStatus
+class MinimalDogStatusFrag_status__IdleStatus
     extends MinimalDogStatusFrag_status {
   static String G__typename = "IdleStatus";
 
@@ -118,7 +118,7 @@ final class MinimalDogStatusFrag_status__IdleStatus
   }
 }
 
-final class MinimalDogStatusFrag_status__MovementStatus
+class MinimalDogStatusFrag_status__MovementStatus
     extends MinimalDogStatusFrag_status {
   static String G__typename = "MovementStatus";
 

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart
@@ -11,7 +11,9 @@ import 'package:collection/collection.dart';
 import 'CommonAnimalFrag.shalom.dart';
 import 'DogFavoriteFrag.shalom.dart';
 import 'DogWithFavoriteToyFrag.shalom.dart';
+import 'ExtendedDogStatusFrag.shalom.dart';
 import 'HasFavoriteToyFrag.shalom.dart';
+import 'MinimalDogStatusFrag.shalom.dart';
 import 'ToyFrag.shalom.dart';
 
 // ------------ OBJECT DEFINITIONS -------------
@@ -131,7 +133,7 @@ class ZooAnimalsContractQuery_animals__Cat
 
 class ZooAnimalsContractQuery_animals__Dog
     extends ZooAnimalsContractQuery_animals
-    implements DogFavoriteFrag, DogWithFavoriteToyFrag {
+    implements DogFavoriteFrag, DogWithFavoriteToyFrag, ExtendedDogStatusFrag {
   static String G__typename = "Dog";
 
   /// class members
@@ -141,6 +143,8 @@ class ZooAnimalsContractQuery_animals__Dog
   final HasFavoriteToyFrag_favoriteToy favoriteToy;
 
   final String id;
+
+  final ExtendedDogStatusFrag_status status;
 
   // Getter for typename (public accessor for static __typename field)
   String get $__typename => G__typename;
@@ -152,6 +156,8 @@ class ZooAnimalsContractQuery_animals__Dog
     required this.favoriteToy,
 
     required this.id,
+
+    required this.status,
   });
 
   @override
@@ -160,7 +166,8 @@ class ZooAnimalsContractQuery_animals__Dog
         (other is ZooAnimalsContractQuery_animals__Dog &&
             breed == other.breed &&
             favoriteToy == other.favoriteToy &&
-            id == other.id);
+            id == other.id &&
+            status == other.status);
   }
 
   @override
@@ -170,6 +177,8 @@ class ZooAnimalsContractQuery_animals__Dog
     favoriteToy,
 
     id,
+
+    status,
 
     ZooAnimalsContractQuery_animals__Dog.G__typename,
   ]);
@@ -183,6 +192,8 @@ class ZooAnimalsContractQuery_animals__Dog
       'favoriteToy': this.favoriteToy.toJson(),
 
       'id': this.id,
+
+      'status': this.status.toJson(),
     };
   }
 
@@ -195,12 +206,18 @@ class ZooAnimalsContractQuery_animals__Dog
           data['favoriteToy'] as shalom_core.JsonObject,
         );
     final String id$value = data['id'] as String;
+    final ExtendedDogStatusFrag_status status$value =
+        ExtendedDogStatusFrag_status.fromJson(
+          data['status'] as shalom_core.JsonObject,
+        );
     return ZooAnimalsContractQuery_animals__Dog(
       breed: breed$value,
 
       favoriteToy: favoriteToy$value,
 
       id: id$value,
+
+      status: status$value,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
@@ -11,7 +11,9 @@ import 'ZooAnimalsContractQuery.shalom.dart';
 import 'CommonAnimalFrag.shalom.dart';
 import 'DogFavoriteFrag.shalom.dart';
 import 'DogWithFavoriteToyFrag.shalom.dart';
+import 'ExtendedDogStatusFrag.shalom.dart';
 import 'HasFavoriteToyFrag.shalom.dart';
+import 'MinimalDogStatusFrag.shalom.dart';
 import 'ToyFrag.shalom.dart';
 
 abstract class $ZooAnimalsContractQuery extends StatefulWidget {

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/animal_contract_query.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/animal_contract_query.dart
@@ -3,8 +3,10 @@ import 'package:shalom_annotations/shalom_annotations.dart';
 
 import '__graphql__/CommonAnimalFrag.shalom.dart';
 import '__graphql__/DogFavoriteFrag.shalom.dart';
+import '__graphql__/ExtendedDogStatusFrag.shalom.dart';
 import '__graphql__/DogWithFavoriteToyFrag.shalom.dart';
 import '__graphql__/HasFavoriteToyFrag.shalom.dart';
+import '__graphql__/MinimalDogStatusFrag.shalom.dart';
 import '__graphql__/ToyFrag.shalom.dart';
 import '__graphql__/ZooAnimalsContractQuery.widget.shalom.dart';
 
@@ -89,6 +91,47 @@ class DogWithFavoriteToyFrag extends $DogWithFavoriteToyFrag {
   }
 }
 
+@Fragment(r'''
+on Dog {
+  status {
+    __typename
+    ... on MovementStatus {
+      motionType
+    }
+  }
+}
+''')
+class MinimalDogStatusFrag extends $MinimalDogStatusFrag {
+  const MinimalDogStatusFrag({super.key, required super.ref});
+
+  @override
+  Widget buildData(BuildContext context, MinimalDogStatusFragData data) {
+    return Text(data.status.$__typename, textDirection: TextDirection.ltr);
+  }
+}
+
+@Fragment(r'''
+on Dog {
+  ...MinimalDogStatusFrag
+  status {
+    ... on StatusInterface {
+      originMessage
+    }
+    ... on MovementStatus {
+      sensitivity
+    }
+  }
+}
+''')
+class ExtendedDogStatusFrag extends $ExtendedDogStatusFrag {
+  const ExtendedDogStatusFrag({super.key, required super.ref});
+
+  @override
+  Widget buildData(BuildContext context, ExtendedDogStatusFragData data) {
+    return Text(data.status.$__typename, textDirection: TextDirection.ltr);
+  }
+}
+
 @Query(r'''
 {
   animals {
@@ -96,6 +139,7 @@ class DogWithFavoriteToyFrag extends $DogWithFavoriteToyFrag {
     ...CommonAnimalFrag
     ...DogFavoriteFrag
     ...DogWithFavoriteToyFrag
+    ...ExtendedDogStatusFrag
   }
 }
 ''')

--- a/rust/shalom_dart_codegen/flutter_tests/test/shared_fragment_contract_test.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/test/shared_fragment_contract_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_tests/shared_fragment_contract/__graphql__/ExtendedDogStatusFrag.shalom.dart';
+import 'package:flutter_tests/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart';
 import 'package:flutter_tests/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart';
 
 void main() {
@@ -8,8 +10,37 @@ void main() {
       'id': 'dog-1',
       'breed': 'Collie',
       'favoriteToy': {'id': 'toy-1', 'label': 'Ball'},
+      'status': {
+        '__typename': 'MovementStatus',
+        'originMessage': 'camera-1',
+        'motionType': 'person',
+        'sensitivity': 8,
+      },
     });
 
     expect(result.favoriteToy.label, 'Ball');
+    expect(result.status.$__typename, 'MovementStatus');
   });
+
+  test(
+    'Flutter fragment nested unions use extendable contracts when spread',
+    () {
+      final data = ExtendedDogStatusFragData.fromCache({
+        'id': 'dog-1',
+        'status': {
+          '__typename': 'MovementStatus',
+          'originMessage': 'camera-1',
+          'motionType': 'person',
+          'sensitivity': 8,
+        },
+      });
+
+      final MinimalDogStatusFrag minimal = data;
+      final status =
+          minimal.status as ExtendedDogStatusFrag_status__MovementStatus;
+      expect(status.motionType, 'person');
+      expect(status.originMessage, 'camera-1');
+      expect(status.sensitivity, 8);
+    },
+  );
 }

--- a/rust/shalom_dart_codegen/flutter_tests/test/shared_fragment_contract_test.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/test/shared_fragment_contract_test.dart
@@ -1,9 +1,28 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tests/shared_fragment_contract/__graphql__/ExtendedDogStatusFrag.shalom.dart';
 import 'package:flutter_tests/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart';
 import 'package:flutter_tests/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart';
 
 void main() {
+  test('Spread-target concrete variant contracts are not final', () {
+    final generated = File(
+      'lib/shared_fragment_contract/__graphql__/MinimalDogStatusFrag.shalom.dart',
+    ).readAsStringSync();
+
+    expect(
+      generated,
+      isNot(contains('final class MinimalDogStatusFrag_status__IdleStatus')),
+    );
+    expect(
+      generated,
+      isNot(
+        contains('final class MinimalDogStatusFrag_status__MovementStatus'),
+      ),
+    );
+  });
+
   test('Flutter operation variants keep fragment contract fields inline', () {
     final result = ZooAnimalsContractQuery_animals__Dog.fromJson({
       '__typename': 'Dog',
@@ -43,4 +62,31 @@ void main() {
       expect(status.sensitivity, 8);
     },
   );
+
+  test('A concrete member produced via a spreading fragment still matches '
+      'switch patterns written against the spread-target fragment (regression '
+      'for helpers like MinimalAlertFragKindDisplay that pattern-match on '
+      "MinimalDogStatusFrag's member types)", () {
+    final data = ExtendedDogStatusFragData.fromCache({
+      'id': 'dog-1',
+      'status': {
+        '__typename': 'MovementStatus',
+        'originMessage': 'camera-1',
+        'motionType': 'person',
+        'sensitivity': 8,
+      },
+    });
+
+    final MinimalDogStatusFrag minimal = data;
+    final MinimalDogStatusFrag_status status = minimal.status;
+
+    final label = switch (status) {
+      MinimalDogStatusFrag_status__IdleStatus() => 'idle',
+      MinimalDogStatusFrag_status__MovementStatus(:final motionType) =>
+        'moving:$motionType',
+      _ => 'unknown',
+    };
+
+    expect(label, 'moving:person');
+  });
 }

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -722,6 +722,72 @@ where
     implemented
 }
 
+/// True if this field (or, for lists, its element type) is itself a nested union/interface
+/// selection. Such fields are resolved to a per-fragment-aliased type name (whichever named
+/// fragment happens to own the selection), so two independently-generated concrete members
+/// that both select the field aren't guaranteed to agree on its type -- unlike scalar/enum
+/// leaves, which always resolve to the same schema type on both sides.
+fn selection_kind_is_nested_multitype(kind: &SelectionKind) -> bool {
+    match kind {
+        SelectionKind::Union(_) | SelectionKind::Interface(_) => true,
+        SelectionKind::List(list) => selection_kind_is_nested_multitype(&list.of_kind),
+        _ => false,
+    }
+}
+
+/// Mirrors `implemented_fragment_selection_types`, but for a concrete union/interface
+/// member (e.g. `ExtendedDogStatusFrag_status__MovementStatus`) rather than the shared
+/// base class. Without this, concrete members generated per-fragment (e.g. by
+/// `MinimalDogStatusFrag` and `ExtendedDogStatusFrag`, which both select `... on MovementStatus`)
+/// are structurally identical but type-system-unrelated, so pattern matching on one
+/// fragment's member never matches an instance produced via a spreading fragment.
+///
+/// Conservatively skips members that have their own nested union/interface fields --
+/// see `selection_kind_is_nested_multitype` -- since those fields' types aren't guaranteed
+/// covariant across fragments and Dart would reject the `implements` clause.
+fn implemented_fragment_member_types<T>(
+    executable_ctx: &T,
+    concrete_subset: &ObjectLikeCommon,
+) -> BTreeSet<String>
+where
+    T: ExecutableContext,
+{
+    let mut implemented = concrete_subset.used_fragments.clone();
+    if concrete_subset
+        .selections
+        .iter()
+        .any(|selection| selection_kind_is_nested_multitype(&selection.kind))
+    {
+        return implemented;
+    }
+    for fragment in executable_ctx.typedefs().flatten_used_fragments() {
+        let Some(fragment_member_path) = fragment_path_for_executable_path(
+            executable_ctx,
+            &fragment,
+            &concrete_subset.path_name,
+        ) else {
+            continue;
+        };
+        let Some((union_path, typename)) = fragment_member_path.rsplit_once("__") else {
+            continue;
+        };
+        let has_member = fragment
+            .typedefs
+            .get_multitype_selection(&union_path.to_string())
+            .map(|multitype| {
+                multitype
+                    .common()
+                    .possible_concrete_types
+                    .contains(typename)
+            })
+            .unwrap_or(false);
+        if has_member {
+            implemented.insert(fragment_member_path);
+        }
+    }
+    implemented
+}
+
 fn register_executable_fns<'a, T>(
     env: &mut Environment<'a>,
     ctx: &SharedShalomGlobalContext,
@@ -768,6 +834,18 @@ where
         move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
             let implemented =
                 implemented_fragment_selection_types(executable_ctx_clone4.as_ref(), &obj_like.0);
+            minijinja::Value::from_serialize(&implemented)
+        },
+    );
+
+    let executable_ctx_clone4 = executable_ctx.clone();
+    env.add_function(
+        "implemented_fragment_member_types",
+        move |concrete_subset: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
+            let implemented = implemented_fragment_member_types(
+                executable_ctx_clone4.as_ref(),
+                &concrete_subset.0,
+            );
             minijinja::Value::from_serialize(&implemented)
         },
     );

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -9,7 +9,7 @@ pub use dart_scanner::{WidgetAnnotation, WidgetKind, scan_dart_widgets};
 use shalom_core::{
     context::{ShalomGlobalContext, SharedShalomGlobalContext},
     operation::{
-        context::{ExecutableContext, OperationContext, SharedOpCtx},
+        context::{ExecutableContext, OperationContext, SharedOpCtx, TypeDefs},
         fragments::{FragmentContext, SharedFragmentContext},
         types::{
             FieldSelection, ObjectLikeCommon, SelectionKind, SharedListSelection,
@@ -24,7 +24,7 @@ use shalom_core::{
 };
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fs,
     hash::{DefaultHasher, Hash, Hasher},
     path::{Path, PathBuf},
@@ -561,6 +561,167 @@ where
     multitype_list_selections
 }
 
+fn fragment_path_for_executable_path<T>(
+    executable_ctx: &T,
+    fragment: &FragmentContext,
+    path_name: &str,
+) -> Option<String>
+where
+    T: ExecutableContext,
+{
+    let root_path = &executable_ctx.get_root().path_name;
+    if path_name == root_path {
+        return None;
+    }
+
+    let suffix = path_name.strip_prefix(&format!("{root_path}_"))?;
+    Some(format!("{}_{}", fragment.name, suffix))
+}
+
+fn executable_path_for_fragment_path(
+    executable_root_path: &str,
+    fragment_name: &str,
+    path_name: &str,
+) -> Option<String> {
+    if path_name == fragment_name {
+        return None;
+    }
+
+    let suffix = path_name.strip_prefix(&format!("{fragment_name}_"))?;
+    Some(format!("{executable_root_path}_{suffix}"))
+}
+
+fn get_object_like_for_path(typedefs: &TypeDefs, path_name: &str) -> Option<ObjectLikeCommon> {
+    if let Some(selection) = typedefs.objects.get(path_name) {
+        return Some(selection.common.clone());
+    }
+    if let Some(selection) = typedefs.unions.get(path_name) {
+        return Some(selection.common.common.clone());
+    }
+    if let Some(selection) = typedefs.interfaces.get(path_name) {
+        return Some(selection.common.common.clone());
+    }
+    None
+}
+
+fn executable_uses_fragment<T>(executable_ctx: &T, fragment_name: &str) -> bool
+where
+    T: ExecutableContext,
+{
+    executable_ctx
+        .typedefs()
+        .flatten_used_fragments()
+        .iter()
+        .any(|fragment| fragment.name == fragment_name)
+}
+
+fn fragment_owner_for_path(global_ctx: &ShalomGlobalContext, path_name: &str) -> Option<String> {
+    global_ctx
+        .fragments()
+        .into_iter()
+        .filter_map(|(name, _)| {
+            if path_name.strip_prefix(&format!("{name}_")).is_some() {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .max_by_key(|name| name.len())
+}
+
+fn selection_is_cross_file_implemented(
+    global_ctx: &ShalomGlobalContext,
+    object_like: &ObjectLikeCommon,
+) -> bool {
+    let Some(fragment_name) = fragment_owner_for_path(global_ctx, &object_like.path_name) else {
+        return false;
+    };
+
+    for (_, fragment) in global_ctx.fragments() {
+        if fragment.name == fragment_name
+            || !executable_uses_fragment(fragment.as_ref(), &fragment_name)
+        {
+            continue;
+        }
+
+        let Some(path) = executable_path_for_fragment_path(
+            &fragment.get_root().path_name,
+            &fragment_name,
+            &object_like.path_name,
+        ) else {
+            continue;
+        };
+
+        if get_object_like_for_path(&fragment.typedefs, &path).is_some() {
+            return true;
+        }
+    }
+
+    for (_, operation) in global_ctx.operations() {
+        if !executable_uses_fragment(operation.as_ref(), &fragment_name) {
+            continue;
+        }
+
+        let Some(path) = executable_path_for_fragment_path(
+            &operation.get_root().path_name,
+            &fragment_name,
+            &object_like.path_name,
+        ) else {
+            continue;
+        };
+
+        if get_object_like_for_path(&operation.typedefs, &path).is_some() {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn object_like_with_fragment_path_matches<T>(
+    executable_ctx: &T,
+    object_like: &ObjectLikeCommon,
+) -> ObjectLikeCommon
+where
+    T: ExecutableContext,
+{
+    let mut merged = object_like.clone();
+    for fragment in executable_ctx.typedefs().flatten_used_fragments() {
+        let Some(fragment_path) =
+            fragment_path_for_executable_path(executable_ctx, &fragment, &object_like.path_name)
+        else {
+            continue;
+        };
+        if let Some(fragment_object_like) =
+            get_object_like_for_path(&fragment.typedefs, &fragment_path)
+        {
+            merged.merge(fragment_object_like);
+        }
+    }
+    merged
+}
+
+fn implemented_fragment_selection_types<T>(
+    executable_ctx: &T,
+    object_like: &ObjectLikeCommon,
+) -> BTreeSet<String>
+where
+    T: ExecutableContext,
+{
+    let mut implemented = object_like.used_fragments.clone();
+    for fragment in executable_ctx.typedefs().flatten_used_fragments() {
+        let Some(fragment_path) =
+            fragment_path_for_executable_path(executable_ctx, &fragment, &object_like.path_name)
+        else {
+            continue;
+        };
+        if get_object_like_for_path(&fragment.typedefs, &fragment_path).is_some() {
+            implemented.insert(fragment_path);
+        }
+    }
+    implemented
+}
+
 fn register_executable_fns<'a, T>(
     env: &mut Environment<'a>,
     ctx: &SharedShalomGlobalContext,
@@ -576,6 +737,46 @@ where
         move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
             let selections = obj_like.0.get_all_selections_distinct(&ctx_clone3);
             minijinja::Value::from_serialize(&selections)
+        },
+    );
+
+    let ctx_clone3 = ctx.clone();
+    let executable_ctx_clone4 = executable_ctx.clone();
+    env.add_function(
+        "get_all_selections_distinct_with_fragment_matches",
+        move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
+            let merged =
+                object_like_with_fragment_path_matches(executable_ctx_clone4.as_ref(), &obj_like.0);
+            let selections = merged.get_all_selections_distinct(&ctx_clone3);
+            minijinja::Value::from_serialize(&selections)
+        },
+    );
+
+    let executable_ctx_clone4 = executable_ctx.clone();
+    env.add_function(
+        "get_shared_selections_with_fragment_matches",
+        move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
+            let merged =
+                object_like_with_fragment_path_matches(executable_ctx_clone4.as_ref(), &obj_like.0);
+            minijinja::Value::from_serialize(&merged.selections)
+        },
+    );
+
+    let executable_ctx_clone4 = executable_ctx.clone();
+    env.add_function(
+        "implemented_fragment_selection_types",
+        move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
+            let implemented =
+                implemented_fragment_selection_types(executable_ctx_clone4.as_ref(), &obj_like.0);
+            minijinja::Value::from_serialize(&implemented)
+        },
+    );
+
+    let ctx_clone3 = ctx.clone();
+    env.add_function(
+        "selection_is_abstract_fragment",
+        move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> bool {
+            selection_is_cross_file_implemented(&ctx_clone3, &obj_like.0)
         },
     );
 
@@ -626,7 +827,9 @@ where
                 &other_obj.schema_typename,
             )
         {
-            resolve_to.selections.extend(other_obj.selections.clone());
+            for selection in other_obj.selections.clone() {
+                resolve_to.add_selection(selection);
+            }
 
             for frag_name in &other_obj.used_fragments {
                 let fragment = global_ctx.get_fragment_strict(frag_name);
@@ -655,7 +858,7 @@ where
                         other_obj.path_name
                     )
                 });
-            resolve_to.selections.insert(typename_selection);
+            resolve_to.add_selection(typename_selection);
         }
 
         for type_cond_obj in other_obj.type_cond_selections.values() {
@@ -673,17 +876,17 @@ where
                 .typedefs()
                 .get_multitype_selection(&fullname)
                 .unwrap_or_else(|| panic!("{fullname} not found"));
+            let multitype_common = object_like_with_fragment_path_matches(
+                executable_ctx_clone2.as_ref(),
+                &multitype.common().common,
+            );
 
             let mut ret = Vec::new();
             for concrete_typename in &multitype.common().possible_concrete_types {
                 let concrete_path = format!("{fullname}__{concrete_typename}");
                 let mut resolved =
                     ObjectLikeCommon::new(concrete_path.clone(), concrete_typename.clone());
-                collect_selections_for_concrete(
-                    &mut resolved,
-                    &multitype.common().common,
-                    &ctx_clone2,
-                );
+                collect_selections_for_concrete(&mut resolved, &multitype_common, &ctx_clone2);
                 resolved.selections = resolved.get_all_selections_distinct(&ctx_clone2);
                 ret.push(resolved);
             }

--- a/rust/shalom_dart_codegen/templates/fragment.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/fragment.dart.jinja
@@ -126,8 +126,10 @@ final class {{ fragment_name }}Data$Unknown extends {{ fragment_name }}Data {
 {% for union_full_name, union_selection in typedefs.unions | items %}
   {% if union_full_name != fragment_name %}
     {% set concretes = multitype_selection_resolved_concretes(union_full_name) -%}
-    sealed class {{ union_full_name }}{{ implements_used_fragments(union_selection.used_fragments) }} {
-      {% for sel in union_selection.selections if sel.name != "__typename" -%}
+    {% set union_shared_selections = get_shared_selections_with_fragment_matches(union_selection) %}
+    {% set is_abstract_fragment = selection_is_abstract_fragment(union_selection) %}
+    {{ "abstract" if is_abstract_fragment else "sealed" }} class {{ union_full_name }}{{ implements_used_fragments(implemented_fragment_selection_types(union_selection)) }} {
+      {% for sel in union_shared_selections if sel.name != "__typename" -%}
         {{type_name_for_selection(sel)}} get {{sel.name}};
       {% endfor %}
       String get $__typename;
@@ -158,8 +160,10 @@ final class {{ fragment_name }}Data$Unknown extends {{ fragment_name }}Data {
 {% for iface_path_name, iface_selection in typedefs.interfaces | items %}
   {% if iface_path_name != fragment_name %}
     {% set concretes = multitype_selection_resolved_concretes(iface_path_name) -%}
-    sealed class {{ iface_path_name }}{{ implements_used_fragments(iface_selection.used_fragments) }} {
-      {% for sel in iface_selection.selections if sel.name != "__typename" -%}
+    {% set iface_shared_selections = get_shared_selections_with_fragment_matches(iface_selection) %}
+    {% set is_abstract_fragment = selection_is_abstract_fragment(iface_selection) %}
+    {{ "abstract" if is_abstract_fragment else "sealed" }} class {{ iface_path_name }}{{ implements_used_fragments(implemented_fragment_selection_types(iface_selection)) }} {
+      {% for sel in iface_shared_selections if sel.name != "__typename" -%}
         {{type_name_for_selection(sel)}} get {{sel.name}};
       {% endfor %}
       String get $__typename;
@@ -355,9 +359,10 @@ class {{ fragment_name }}Impl implements {{ fragment_name }} {
 
 {% for union_full_name, union_selection in typedefs.unions | items -%}
     {% set concretes = multitype_selection_resolved_concretes(union_full_name) -%}
+    {% set union_shared_selections = get_shared_selections_with_fragment_matches(union_selection) %}
     {# generate abstract class (not sealed - must be implementable across libraries by operation types) #}
-    abstract class {{ union_full_name }}{{ implements_used_fragments(union_selection.used_fragments) }} {
-        {% for sel in union_selection.selections if sel.name != "__typename" -%}
+    abstract class {{ union_full_name }}{{ implements_used_fragments(implemented_fragment_selection_types(union_selection)) }} {
+        {% for sel in union_shared_selections if sel.name != "__typename" -%}
             {{type_name_for_selection(sel)}} get {{sel.name}};
         {% endfor %}
         String get $__typename;
@@ -393,9 +398,10 @@ class {{ fragment_name }}Impl implements {{ fragment_name }} {
 
 {% for iface_path_name, iface_selection in typedefs.interfaces | items %}
     {% set concretes = multitype_selection_resolved_concretes(iface_path_name) -%}
+    {% set iface_shared_selections = get_shared_selections_with_fragment_matches(iface_selection) %}
     {# generate abstract class (not sealed - must be implementable across libraries by operation types) #}
-    abstract class {{ iface_path_name }}{{ implements_used_fragments(iface_selection.used_fragments) }} {
-        {% for sel in iface_selection.selections if sel.name != "__typename" -%}
+    abstract class {{ iface_path_name }}{{ implements_used_fragments(implemented_fragment_selection_types(iface_selection)) }} {
+        {% for sel in iface_shared_selections if sel.name != "__typename" -%}
             {{type_name_for_selection(sel)}} get {{sel.name}};
         {% endfor %}
         String get $__typename;

--- a/rust/shalom_dart_codegen/templates/fragment.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/fragment.dart.jinja
@@ -149,7 +149,7 @@ final class {{ fragment_name }}Data$Unknown extends {{ fragment_name }}Data {
       }
     }
     {% for concrete_subset in concretes -%}
-      final class {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+      {{ "class" if is_abstract_fragment else "final class" }} {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
         {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections, use_observe=false) }}
       }
     {% endfor %}
@@ -183,7 +183,7 @@ final class {{ fragment_name }}Data$Unknown extends {{ fragment_name }}Data {
       }
     }
     {% for concrete_subset in concretes -%}
-      final class {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+      {{ "class" if is_abstract_fragment else "final class" }} {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
         {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections, use_observe=false) }}
       }
     {% endfor %}
@@ -199,9 +199,10 @@ final class {{ fragment_name }}Data$Unknown extends {{ fragment_name }}Data {
 {# Nested union definitions (fields of union type within this concrete object) #}
 {% for union_full_name, union_selection in typedefs.unions | items %}
   {% set concretes = multitype_selection_resolved_concretes(union_full_name) -%}
+  {% set is_abstract_fragment = selection_is_abstract_fragment(union_selection) %}
   {{ multi_type_selection_definition(union_full_name, union_selection, concretes) }}
   {% for concrete_subset in concretes -%}
-    final class {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+    {{ "class" if is_abstract_fragment else "final class" }} {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
       {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections, use_observe=false) }}
     }
   {% endfor %}
@@ -210,9 +211,10 @@ final class {{ fragment_name }}Data$Unknown extends {{ fragment_name }}Data {
 {# Nested interface definitions (fields of interface type within this concrete object) #}
 {% for iface_path_name, iface_selection in typedefs.interfaces | items %}
   {% set concretes = multitype_selection_resolved_concretes(iface_path_name) -%}
+  {% set is_abstract_fragment = selection_is_abstract_fragment(iface_selection) %}
   {{ multi_type_selection_definition(iface_path_name, iface_selection, concretes) }}
   {% for concrete_subset in concretes -%}
-    final class {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+    {{ "class" if is_abstract_fragment else "final class" }} {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
       {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections, use_observe=false) }}
     }
   {% endfor %}
@@ -386,7 +388,7 @@ class {{ fragment_name }}Impl implements {{ fragment_name }} {
 
     {# generate subsets #}
     {% for concrete_subset in concretes -%}
-        class {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+        class {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
             {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections) }}
         }
     {% endfor %}
@@ -426,7 +428,7 @@ class {{ fragment_name }}Impl implements {{ fragment_name }} {
     {# generate subsets #}
     {% set concretes = multitype_selection_resolved_concretes(iface_path_name) -%}
     {% for concrete_subset in concretes -%}
-        class {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+        class {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
             {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections) }}
         }
     {% endfor %}

--- a/rust/shalom_dart_codegen/templates/operation.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation.dart.jinja
@@ -50,7 +50,7 @@ class {{ response_class_name }} {% if not is_observe %}{{ implements_used_fragme
 
     {# generate subsets #}
     {% for concrete_subset in concretes -%}
-        class {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(concrete_subset.used_fragments)}} {
+        class {{ concrete_subset.path_name }} extends {{ union_full_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}} {
             {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections, use_observe=false) }}
         }
     {% endfor %}
@@ -67,7 +67,7 @@ class {{ response_class_name }} {% if not is_observe %}{{ implements_used_fragme
 
     {# generate subsets #}
     {% for concrete_subset in concretes -%}
-        class {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(concrete_subset.used_fragments)}}  {
+        class {{ concrete_subset.path_name }} extends {{ iface_path_name }} {{implements_used_fragments(implemented_fragment_member_types(concrete_subset))}}  {
             {{ selection_object_impl(concrete_subset.path_name, concrete_subset, is_root_selection=false, full_name=concrete_subset.path_name, is_multi_type_member=true, shared_selections=concrete_subset.selections, use_observe=false) }}
         }
     {% endfor %}

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -307,8 +307,8 @@ null
 {% endmacro %}
 
 {% macro selection_object_definition(object, use_observe=true, implement_fragments=true) -%}
-    class {{ object.path_name }} {% if implement_fragments %}{{ implements_used_fragments(object.used_fragments) }}{% endif %}  {
-        {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_distinct(object), use_observe=use_observe) }}
+    class {{ object.path_name }} {% if implement_fragments %}{{ implements_used_fragments(implemented_fragment_selection_types(object)) }}{% endif %}  {
+        {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_distinct_with_fragment_matches(object), use_observe=use_observe) }}
     }
 {% endmacro %}
 
@@ -316,11 +316,13 @@ null
 
 {# Unified macro for union and interface selection -#}
 {% macro multi_type_selection_definition(full_name, selection, possible_concretes) -%}
-    sealed class {{ full_name }}{{ implements_used_fragments(selection.used_fragments) }} {
+    {% set shared_selections = get_shared_selections_with_fragment_matches(selection) %}
+    {% set is_abstract_fragment = selection_is_abstract_fragment(selection) %}
+    {{ "abstract" if is_abstract_fragment else "sealed" }} class {{ full_name }}{{ implements_used_fragments(implemented_fragment_selection_types(selection)) }} {
 
 
-        {% for selection in selection.selections if selection.name != "__typename" -%}
-            {{type_name_for_selection(selection)}} get {{selection.name}};
+        {% for shared_selection in shared_selections if shared_selection.name != "__typename" -%}
+            {{type_name_for_selection(shared_selection)}} get {{shared_selection.name}};
         {% endfor %}
         String get $__typename;
         const {{ full_name }}();

--- a/rust/shalom_runtime/src/selection.rs
+++ b/rust/shalom_runtime/src/selection.rs
@@ -1,10 +1,12 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use serde_json::{Map, Value};
 
 use shalom_core::{
     context::SharedShalomGlobalContext,
-    operation::types::{ArgumentValue, FieldArgument, FieldSelection, InlineValueArg},
+    operation::types::{
+        ArgumentValue, FieldArgument, FieldSelection, InlineValueArg, merge_selection_into_set,
+    },
 };
 
 pub fn resolve_object_selections(
@@ -22,7 +24,7 @@ pub fn resolve_multitype_selections(
     typename: &str,
     ctx: &SharedShalomGlobalContext,
 ) -> Vec<FieldSelection> {
-    let mut selections = HashSet::new();
+    let mut selections = BTreeSet::new();
 
     /// Whether `root_type` satisfies a type condition named `cond_typename` -
     /// either directly, via interface implementation, or by being a member of
@@ -49,12 +51,14 @@ pub fn resolve_multitype_selections(
         root_type: &str,
         current_obj: &shalom_core::operation::types::ObjectLikeCommon,
         ctx: &SharedShalomGlobalContext,
-        selections: &mut HashSet<FieldSelection>,
+        selections: &mut BTreeSet<FieldSelection>,
     ) {
         let include_shared =
             type_condition_covers_root(root_type, &current_obj.schema_typename, ctx);
         if include_shared {
-            selections.extend(current_obj.selections.iter().cloned());
+            for selection in current_obj.selections.iter().cloned() {
+                merge_selection_into_set(selections, selection);
+            }
         }
 
         for frag_name in current_obj.used_fragments.iter() {

--- a/rust/shalom_runtime/tests/cache.rs
+++ b/rust/shalom_runtime/tests/cache.rs
@@ -2204,3 +2204,102 @@ mod incomplete_cache_emissions {
         runtime.unsubscribe(&sub_id);
     }
 }
+
+mod duplicate_field_selection_merge {
+    use super::*;
+
+    /// Two fragments selecting the same field with different sub-selections
+    /// (a minimal `channelAlert { __typename }` and a wide variant selection)
+    /// must be merged, not deduplicated by field name. A name-only dedup used
+    /// to drop the wide selection, so normalization discarded the variant
+    /// fields and reads returned a "complete" object missing them.
+    const SCHEMA: &str = r#"
+        type Query { alert: Alert }
+        type Alert { id: ID!, data: Data! }
+        union Data = Nvr | Plain
+        type Nvr { channelAlert: Inner!, channel: Int! }
+        type Plain { message: String! }
+        union Inner = Motion | Loss
+        type Motion { motionType: String!, originMessage: String }
+        type Loss { originMessage: String }
+    "#;
+
+    const OPERATION: &str = r#"
+        fragment InnerFrag on Nvr {
+            channelAlert {
+                __typename
+                ... on Motion { motionType originMessage }
+                ... on Loss { originMessage }
+            }
+            channel
+        }
+        fragment MinimalFrag on Alert {
+            id
+            data {
+                __typename
+                ... on Nvr { channelAlert { __typename } }
+                ... on Plain { message }
+            }
+        }
+        fragment FullFrag on Alert {
+            ...MinimalFrag
+            data {
+                ... on Nvr { ...InnerFrag }
+            }
+        }
+        query TestOp {
+            alert { ...FullFrag }
+        }
+    "#;
+
+    fn response() -> Value {
+        json!({
+            "alert": {
+                "__typename": "Alert",
+                "id": "a1",
+                "data": {
+                    "__typename": "Nvr",
+                    "channelAlert": {
+                        "__typename": "Motion",
+                        "motionType": "HUMAN",
+                        "originMessage": "hi"
+                    },
+                    "channel": 3
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn test_normalize_keeps_both_narrow_and_wide_fields() {
+        let (runtime, op_ctx) = build_ctx(SCHEMA, OPERATION);
+        normalize(&runtime, &op_ctx, response(), None);
+
+        let alert = record(&runtime, "Alert:a1");
+        let data = match alert.get("data").expect("data missing") {
+            CacheValue::Object(record) => record.clone(),
+            other => panic!("expected embedded object for data, got {other:?}"),
+        };
+        let channel_alert = match data.get("channelAlert").expect("channelAlert missing") {
+            CacheValue::Object(record) => record.clone(),
+            other => panic!("expected embedded object for channelAlert, got {other:?}"),
+        };
+        expect_scalar(&channel_alert, "motionType", json!("HUMAN"));
+        expect_scalar(&channel_alert, "originMessage", json!("hi"));
+        expect_scalar(&data, "channel", json!(3));
+    }
+
+    #[test]
+    fn test_read_fragment_resolves_merged_selection() {
+        let (runtime, op_ctx) = build_ctx(SCHEMA, OPERATION);
+        normalize(&runtime, &op_ctx, response(), None);
+
+        let read = runtime
+            .try_read_fragment("FullFrag", "Alert:a1")
+            .expect("read fragment")
+            .expect("fragment should be complete in cache");
+        assert_eq!(read["data"]["channelAlert"]["motionType"], json!("HUMAN"));
+        assert_eq!(read["data"]["channelAlert"]["__typename"], json!("Motion"));
+        assert_eq!(read["data"]["channel"], json!(3));
+    }
+}


### PR DESCRIPTION
Enhance the GraphQL selection logic to correctly merge nested object and union fields when fragments are spread. Update the codegen templates and selection merging algorithms to support fragment inheritance and field aggregation.

## Summary by Sourcery

Improve GraphQL selection merging to support fragment-driven inheritance of nested object, interface, and union fields in Dart/Flutter codegen.

New Features:
- Support fragment-aware merging of nested object, interface, union, and list selections in the core operation model.
- Generate Dart selection and fragment contract types that aggregate fields from spread fragments, including nested unions and interfaces.
- Add new GraphQL schema and Dart/Flutter fragments for animal status and nested alert types to exercise fragment inheritance in contracts.

Enhancements:
- Refine selection resolution logic to deduplicate and merge field selections across type conditions and fragments based on ownership paths.
- Extend codegen templates to distinguish abstract vs sealed multi-type selection bases and to expose shared selections derived from fragment spreads.

Tests:
- Add Dart and Flutter tests and fixtures validating that fragments spreading other fragments correctly merge nested object and union fields and remain assignable across shared contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer `status` modeling via a new interface and union, with expanded generated Flutter/Dart fragments/queries to read, observe, and render nested union/interface data.
* **Bug Fixes**
  * Improved fragment-aware selection merging across nested unions/interfaces so duplicate field selections are combined with their sub-selections.
  * Updated runtime selection aggregation to merge deterministically using ordered sets.
* **Tests**
  * Added coverage for duplicate fragment field selection merging and fragment inheritance across interface/union hierarchies.
* **Documentation**
  * Refined README and SKILL.md formatting and fragment-composition guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->