### PR TITLE
wip: less json se(deserialize) roundtrips 

### DIFF
--- a/dart/shalom/lib/shalom.dart
+++ b/dart/shalom/lib/shalom.dart
@@ -8,7 +8,8 @@ export 'src/scalar.dart';
 
 export 'src/transport/http_link.dart'
     show HttpLink, HttpMethod, ShalomHttpTransport;
-export 'src/transport/link.dart' show GraphQLLink, ShalomClient;
+export 'src/transport/link.dart'
+    show GraphQLLink, ShalomClient, parseGraphQLResponseBytes;
 export 'src/transport/ws_link.dart' show WebSocketLink;
 export 'src/transport/ws_transport.dart' show WebSocketTransport, MessageSender;
 export 'src/transport/web_socket_transport.dart' show WebSocketPackageTransport;

--- a/dart/shalom/lib/src/runtime_client.dart
+++ b/dart/shalom/lib/src/runtime_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     show ExternalLibrary;
@@ -65,8 +66,7 @@ rs_runtime.RuntimeConfigInput runtimeConfig({
 class ShalomRuntimeClient {
   final rs_runtime.RuntimeHandle _handle;
   final GraphQLLink _link;
-  final Map<int, StreamSubscription<GraphQLResponse<JsonObject>>>
-  _activeRequests = {};
+  final Map<int, StreamSubscription<void>> _activeRequests = {};
   StreamSubscription<String>? _requestStream;
   bool _disposed = false;
 
@@ -430,10 +430,13 @@ class ShalomRuntimeClient {
       opName: envelope.operationName,
     );
 
+    // The link hands back the exact response bytes; forward them straight to
+    // the Rust runtime, which does the JSON parsing — no jsonDecode/jsonEncode
+    // round trip on the Dart side.
     final subscription = _link
         .request(request: request)
         .listen(
-          (response) => _dispatchResponse(envelope.id, response),
+          (bytes) => _pushResponseBytes(envelope.id, bytes),
           onError: (error) => _dispatchTransportError(envelope.id, error),
           onDone: () {
             _activeRequests.remove(envelope.id);
@@ -446,31 +449,11 @@ class ShalomRuntimeClient {
     _activeRequests[envelope.id] = subscription;
   }
 
-  void _dispatchResponse(int requestId, GraphQLResponse<JsonObject> response) {
-    switch (response) {
-      case GraphQLData():
-        final payload = <String, dynamic>{'data': response.data};
-        if (response.errors != null) payload['errors'] = response.errors;
-        if (response.extensions != null) {
-          payload['extensions'] = response.extensions;
-        }
-        return _pushResponse(requestId, payload);
-      case GraphQLError():
-        final payload = <String, dynamic>{'errors': response.errors};
-        if (response.extensions != null) {
-          payload['extensions'] = response.extensions;
-        }
-        return _pushResponse(requestId, payload);
-      case LinkExceptionResponse():
-        _dispatchTransportError(requestId, response.errors);
-    }
-  }
-
-  void _pushResponse(int requestId, Map<String, dynamic> payload) {
-    return rs_runtime.pushResponse(
+  void _pushResponseBytes(int requestId, Uint8List bytes) {
+    return rs_runtime.pushResponseBytes(
       handle: _handle,
       requestId: BigInt.from(requestId),
-      responseJson: jsonEncode(payload),
+      responseBytes: bytes,
     );
   }
 

--- a/dart/shalom/lib/src/rust/api/runtime.dart
+++ b/dart/shalom/lib/src/rust/api/runtime.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'runtime.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `cache_value_to_json`, `parse_graphql_response`, `parse_optional_json`, `parse_variables`, `response_to_json`, `to_link_op_type`, `to_observer_info`
+// These functions are ignored because they are not marked as `pub`: `cache_value_to_json`, `graphql_response_from_value`, `parse_graphql_response_bytes`, `parse_optional_json`, `parse_variables`, `response_to_json`, `to_link_op_type`, `to_observer_info`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `from`, `from`, `from`, `from`
 
 /// Set the global log level filter for all Rust-side logging.
@@ -144,14 +144,18 @@ Stream<SubscriptionEvent> listenSubscription({
 Stream<String> listenRequests({required RuntimeHandle handle}) =>
     RustLib.instance.api.crateApiRuntimeListenRequests(handle: handle);
 
-void pushResponse({
+/// Push a network response for `request_id`. Takes the raw response bytes
+/// (e.g. the exact bytes of an HTTP response body) rather than a JSON
+/// string, so Dart-side transports never need to parse the response into a
+/// `Map` before handing it off — Rust does the JSON parsing.
+void pushResponseBytes({
   required RuntimeHandle handle,
   required BigInt requestId,
-  required String responseJson,
-}) => RustLib.instance.api.crateApiRuntimePushResponse(
+  required List<int> responseBytes,
+}) => RustLib.instance.api.crateApiRuntimePushResponseBytes(
   handle: handle,
   requestId: requestId,
-  responseJson: responseJson,
+  responseBytes: responseBytes,
 );
 
 void pushTransportError({

--- a/dart/shalom/lib/src/rust/frb_generated.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -885489623;
+  int get rustContentHash => -106294496;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -123,10 +123,10 @@ abstract class RustLibApi extends BaseApi {
     required ObservedRefInput refInput,
   });
 
-  void crateApiRuntimePushResponse({
+  void crateApiRuntimePushResponseBytes({
     required RuntimeHandle handle,
     required BigInt requestId,
-    required String responseJson,
+    required List<int> responseBytes,
   });
 
   void crateApiRuntimePushTransportError({
@@ -648,10 +648,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  void crateApiRuntimePushResponse({
+  void crateApiRuntimePushResponseBytes({
     required RuntimeHandle handle,
     required BigInt requestId,
-    required String responseJson,
+    required List<int> responseBytes,
   }) {
     return handler.executeSync(
       SyncTask(
@@ -662,24 +662,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(requestId, serializer);
-          sse_encode_String(responseJson, serializer);
+          sse_encode_list_prim_u_8_loose(responseBytes, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: sse_decode_AnyhowException,
         ),
-        constMeta: kCrateApiRuntimePushResponseConstMeta,
-        argValues: [handle, requestId, responseJson],
+        constMeta: kCrateApiRuntimePushResponseBytesConstMeta,
+        argValues: [handle, requestId, responseBytes],
         apiImpl: this,
       ),
     );
   }
 
-  TaskConstMeta get kCrateApiRuntimePushResponseConstMeta =>
+  TaskConstMeta get kCrateApiRuntimePushResponseBytesConstMeta =>
       const TaskConstMeta(
-        debugName: "push_response",
-        argNames: ["handle", "requestId", "responseJson"],
+        debugName: "push_response_bytes",
+        argNames: ["handle", "requestId", "responseBytes"],
       );
 
   @override
@@ -1580,6 +1580,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as List<int>;
+  }
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
@@ -1921,6 +1927,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ans_.add(sse_decode_observer_info(deserializer));
     }
     return ans_;
+  }
+
+  @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var len_ = sse_decode_i_32(deserializer);
+    return deserializer.buffer.getUint8List(len_);
   }
 
   @protected
@@ -2327,6 +2340,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     for (final item in self) {
       sse_encode_observer_info(item, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_list_prim_u_8_loose(
+    List<int> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    serializer.buffer.putUint8List(
+      self is Uint8List ? self : Uint8List.fromList(self),
+    );
   }
 
   @protected

--- a/dart/shalom/lib/src/rust/frb_generated.io.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.io.dart
@@ -107,6 +107,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ObserverInfo> dco_decode_list_observer_info(dynamic raw);
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -244,6 +247,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ObserverInfo> sse_decode_list_observer_info(
     SseDeserializer deserializer,
   );
+
+  @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -402,6 +408,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     List<ObserverInfo> self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_u_8_strict(

--- a/dart/shalom/lib/src/rust/frb_generated.web.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.web.dart
@@ -109,6 +109,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ObserverInfo> dco_decode_list_observer_info(dynamic raw);
 
   @protected
+  List<int> dco_decode_list_prim_u_8_loose(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -246,6 +249,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<ObserverInfo> sse_decode_list_observer_info(
     SseDeserializer deserializer,
   );
+
+  @protected
+  List<int> sse_decode_list_prim_u_8_loose(SseDeserializer deserializer);
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -404,6 +410,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     List<ObserverInfo> self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_list_prim_u_8_loose(List<int> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_u_8_strict(

--- a/dart/shalom/lib/src/transport/http_link.dart
+++ b/dart/shalom/lib/src/transport/http_link.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:shalom/src/shalom_core_base.dart';
@@ -13,7 +14,10 @@ enum HttpMethod {
 }
 
 abstract class ShalomHttpTransport {
-  Future<JsonObject> request({
+  /// Performs the HTTP request and returns the raw, still-encoded response
+  /// body bytes. Implementations should NOT parse the body as JSON — decoding
+  /// happens downstream (in Rust) to avoid a redundant decode/re-encode.
+  Future<Uint8List> request({
     required HttpMethod method,
     required String url,
     required JsonObject data,
@@ -44,7 +48,7 @@ class HttpLink extends GraphQLLink {
   });
 
   @override
-  Stream<GraphQLResponse<JsonObject>> request({
+  Stream<Uint8List> request({
     required Request request,
     HeadersType? headers,
   }) async* {
@@ -73,24 +77,19 @@ class HttpLink extends GraphQLLink {
         ];
       }
 
-      // Make the request through the transport layer
-      final $response = await transportLayer.request(
+      // Make the request through the transport layer, and hand its bytes
+      // straight through — no JSON decoding happens on the Dart side.
+      yield await transportLayer.request(
         method: methodForThisRequest,
         url: url,
         data: requestBody,
         headers: finalHeaders,
       );
-
-      // Parse and yield the response
-      yield _parseResponse($response);
     } catch (e) {
-      // Return a link error for any exceptions
-      yield LinkExceptionResponse([
-        ShalomTransportException(
-          message: 'Network error: ${e.toString()}',
-          code: 'NETWORK_ERROR',
-        ),
-      ]);
+      throw ShalomTransportException(
+        message: 'Network error: ${e.toString()}',
+        code: 'NETWORK_ERROR',
+      );
     }
   }
 
@@ -139,76 +138,5 @@ class HttpLink extends GraphQLLink {
       ...headers,
       ("Accept", 'application/graphql-response+json, application/json;q=0.9'),
     ];
-  }
-
-  /// Parses the transport layer response into a GraphQLResponse
-  GraphQLResponse<JsonObject> _parseResponse(JsonObject response) {
-    try {
-      final data = response['data'];
-
-      // Check for errors field
-      final errors = response['errors'];
-      List<JsonObject>? parsedErrors;
-
-      if (errors != null) {
-        if (errors is List) {
-          parsedErrors = errors.map((e) => e as JsonObject).toList();
-        } else {
-          return LinkExceptionResponse([
-            ShalomTransportException(
-              message: 'Invalid errors format: expected array',
-              code: 'INVALID_RESPONSE_FORMAT',
-            ),
-          ]);
-        }
-      }
-
-      // Check for extensions field
-      final extensionsRaw = response['extensions'];
-      final JsonObject? $extensions =
-          extensionsRaw != null && extensionsRaw is Map
-          ? Map<String, dynamic>.from(extensionsRaw)
-          : null;
-
-      // According to GraphQL spec:
-      // - If data is not null, it's a valid response
-      // - If data is null or absent, errors must be present
-      if (data != null) {
-        // Handle data field - it must be a map
-        if (data is Map) {
-          return GraphQLData(
-            data: data as JsonObject,
-            errors: parsedErrors,
-            extensions: $extensions,
-          );
-        } else {
-          // Invalid data type
-          return LinkExceptionResponse([
-            ShalomTransportException(
-              message: 'Invalid data format: expected JSON object',
-              code: 'INVALID_RESPONSE_FORMAT',
-            ),
-          ]);
-        }
-      } else if (parsedErrors != null) {
-        // No valid data, but has errors - this is a GraphQL error response
-        return GraphQLError(errors: parsedErrors, extensions: $extensions);
-      } else {
-        // Neither valid data nor errors - invalid response
-        return LinkExceptionResponse([
-          ShalomTransportException(
-            message: 'Invalid GraphQL response: missing both data and errors',
-            code: 'INVALID_RESPONSE_FORMAT',
-          ),
-        ]);
-      }
-    } catch (e) {
-      return LinkExceptionResponse([
-        ShalomTransportException(
-          message: 'Failed to parse response: ${e.toString()}',
-          code: 'RESPONSE_PARSE_ERROR',
-        ),
-      ]);
-    }
   }
 }

--- a/dart/shalom/lib/src/transport/link.dart
+++ b/dart/shalom/lib/src/transport/link.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import '../shalom_core_base.dart'
     show
@@ -9,15 +11,91 @@ import '../shalom_core_base.dart'
         JsonObject,
         LinkExceptionResponse,
         Request,
-        RequestMeta;
+        RequestMeta,
+        ShalomTransportException;
 
+/// A GraphQL transport. Yields the exact, still-encoded response bytes for
+/// each request — no JSON decoding happens here. [ShalomRuntimeClient] hands
+/// these bytes straight to the Rust runtime, which does the parsing; callers
+/// that need a decoded [GraphQLResponse] (e.g. [ShalomClient]) decode it
+/// themselves via [parseGraphQLResponseBytes].
 abstract class GraphQLLink {
-  Stream<GraphQLResponse<JsonObject>> request({
-    required Request request,
-    HeadersType? headers,
-  });
+  Stream<Uint8List> request({required Request request, HeadersType? headers});
 }
 
+/// Decodes raw response bytes into a [GraphQLResponse], applying the
+/// GraphQL-over-HTTP rules: `data` present -> [GraphQLData], `data` absent
+/// with `errors` present -> [GraphQLError], otherwise a [LinkExceptionResponse].
+GraphQLResponse<JsonObject> parseGraphQLResponseBytes(Uint8List bytes) {
+  try {
+    final response = jsonDecode(utf8.decode(bytes));
+    if (response is! JsonObject) {
+      return LinkExceptionResponse([
+        ShalomTransportException(
+          message: 'Invalid GraphQL response: expected a JSON object',
+          code: 'INVALID_RESPONSE_FORMAT',
+        ),
+      ]);
+    }
+
+    final data = response['data'];
+    final errors = response['errors'];
+    List<JsonObject>? parsedErrors;
+
+    if (errors != null) {
+      if (errors is List) {
+        parsedErrors = errors.map((e) => e as JsonObject).toList();
+      } else {
+        return LinkExceptionResponse([
+          ShalomTransportException(
+            message: 'Invalid errors format: expected array',
+            code: 'INVALID_RESPONSE_FORMAT',
+          ),
+        ]);
+      }
+    }
+
+    final extensionsRaw = response['extensions'];
+    final JsonObject? extensions =
+        extensionsRaw != null && extensionsRaw is Map
+        ? Map<String, dynamic>.from(extensionsRaw)
+        : null;
+
+    if (data != null) {
+      if (data is Map) {
+        return GraphQLData(
+          data: data as JsonObject,
+          errors: parsedErrors,
+          extensions: extensions,
+        );
+      }
+      return LinkExceptionResponse([
+        ShalomTransportException(
+          message: 'Invalid data format: expected JSON object',
+          code: 'INVALID_RESPONSE_FORMAT',
+        ),
+      ]);
+    } else if (parsedErrors != null) {
+      return GraphQLError(errors: parsedErrors, extensions: extensions);
+    }
+    return LinkExceptionResponse([
+      ShalomTransportException(
+        message: 'Invalid GraphQL response: missing both data and errors',
+        code: 'INVALID_RESPONSE_FORMAT',
+      ),
+    ]);
+  } catch (e) {
+    return LinkExceptionResponse([
+      ShalomTransportException(
+        message: 'Failed to parse response: ${e.toString()}',
+        code: 'RESPONSE_PARSE_ERROR',
+      ),
+    ]);
+  }
+}
+
+/// Standalone GraphQL client that decodes responses in Dart, for use without
+/// the Rust-backed [ShalomRuntimeClient]/normalized cache.
 class ShalomClient {
   final GraphQLLink link;
   const ShalomClient({required this.link});
@@ -27,32 +105,15 @@ class ShalomClient {
     HeadersType? headers,
   }) {
     final controller = StreamController<GraphQLResponse<T>>();
-    StreamSubscription<GraphQLResponse<JsonObject>>? linkSubscription;
+    StreamSubscription<Uint8List>? linkSubscription;
 
     controller.onListen = () {
       linkSubscription = link
           .request(request: meta.request, headers: headers)
           .listen(
-            (response) {
+            (bytes) {
               if (controller.isClosed) return;
-
-              switch (response) {
-                case GraphQLData(:final data, :final errors, :final extensions):
-                  final deserialized = meta.parseFn(data);
-                  controller.add(
-                    GraphQLData(
-                      data: deserialized,
-                      errors: errors,
-                      extensions: extensions,
-                    ),
-                  );
-                case GraphQLError(:final errors, :final extensions):
-                  controller.add(
-                    GraphQLError(errors: errors, extensions: extensions),
-                  );
-                case LinkExceptionResponse(:final errors):
-                  controller.add(LinkExceptionResponse(errors));
-              }
+              controller.add(_decode(bytes, meta));
             },
             onError: (error) {
               if (!controller.isClosed) {
@@ -78,24 +139,27 @@ class ShalomClient {
     required RequestMeta<T> meta,
     HeadersType? headers,
   }) async {
-    await for (final res in link.request(
+    await for (final bytes in link.request(
       request: meta.request,
       headers: headers,
     )) {
-      switch (res) {
-        case GraphQLData(:final data, :final errors, :final extensions):
-          final deserialized = meta.parseFn(data);
-          return GraphQLData(
-            data: deserialized,
-            errors: errors,
-            extensions: extensions,
-          );
-        case GraphQLError(:final errors, :final extensions):
-          return GraphQLError(errors: errors, extensions: extensions);
-        case LinkExceptionResponse(:final errors):
-          return LinkExceptionResponse(errors);
-      }
+      return _decode(bytes, meta);
     }
     throw Exception("Stream closed without emitting a response");
+  }
+
+  GraphQLResponse<T> _decode<T>(Uint8List bytes, RequestMeta<T> meta) {
+    switch (parseGraphQLResponseBytes(bytes)) {
+      case GraphQLData(:final data, :final errors, :final extensions):
+        return GraphQLData(
+          data: meta.parseFn(data),
+          errors: errors,
+          extensions: extensions,
+        );
+      case GraphQLError(:final errors, :final extensions):
+        return GraphQLError(errors: errors, extensions: extensions);
+      case LinkExceptionResponse(:final errors):
+        return LinkExceptionResponse(errors);
+    }
   }
 }

--- a/dart/shalom/lib/src/transport/ws_link.dart
+++ b/dart/shalom/lib/src/transport/ws_link.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-import 'dart:convert' show json;
+import 'dart:convert' show json, utf8;
 import 'dart:developer' show log;
+import 'dart:typed_data';
 
 import 'package:shalom/src/rust/api/ws.dart';
 import 'package:shalom/src/shalom_core_base.dart';
@@ -169,22 +170,17 @@ class WebSocketLink extends GraphQLLink {
           log('WebSocketLink: unknown op $opId');
           return;
         }
-        final data = dataJson != null
-            ? json.decode(dataJson) as JsonObject
-            : null;
-        final errors = errorsJson != null
-            ? (json.decode(errorsJson) as List).cast<JsonObject>()
-            : null;
-        final extensions = extensionsJson != null
-            ? json.decode(extensionsJson) as JsonObject
-            : null;
-        if (data != null) {
+        // dataJson/errorsJson/extensionsJson are already-serialised JSON
+        // fragments from Rust — stitch them into the response body directly
+        // instead of decoding and re-encoding them.
+        if (dataJson != null || errorsJson != null) {
+          final fields = <String>[
+            if (dataJson != null) '"data":$dataJson',
+            if (errorsJson != null) '"errors":$errorsJson',
+            if (extensionsJson != null) '"extensions":$extensionsJson',
+          ];
           handler.controller.add(
-            GraphQLData(data: data, errors: errors, extensions: extensions),
-          );
-        } else if (errors != null) {
-          handler.controller.add(
-            GraphQLError(errors: errors, extensions: extensions),
+            Uint8List.fromList(utf8.encode('{${fields.join(',')}}')),
           );
         }
 
@@ -199,12 +195,9 @@ class WebSocketLink extends GraphQLLink {
   // ── operations ────────────────────────────────────────────────────────────
 
   @override
-  Stream<GraphQLResponse<JsonObject>> request({
-    required Request request,
-    HeadersType? headers,
-  }) {
+  Stream<Uint8List> request({required Request request, HeadersType? headers}) {
     final opId = (_nextOpId++).toString();
-    final controller = StreamController<GraphQLResponse<JsonObject>>();
+    final controller = StreamController<Uint8List>();
     final handler = _OperationHandler(
       id: opId,
       request: request,
@@ -272,13 +265,11 @@ class WebSocketLink extends GraphQLLink {
   void _handleTransportError(dynamic error) {
     for (final h in _ops.values) {
       if (!h.controller.isClosed) {
-        h.controller.add(
-          LinkExceptionResponse([
-            ShalomTransportException(
-              message: 'WebSocket error: $error',
-              code: 'WEBSOCKET_ERROR',
-            ),
-          ]),
+        h.controller.addError(
+          ShalomTransportException(
+            message: 'WebSocket error: $error',
+            code: 'WEBSOCKET_ERROR',
+          ),
         );
       }
     }
@@ -287,13 +278,11 @@ class WebSocketLink extends GraphQLLink {
   void _handleConnectionError(dynamic error) {
     for (final h in _ops.values) {
       if (!h.controller.isClosed) {
-        h.controller.add(
-          LinkExceptionResponse([
-            ShalomTransportException(
-              message: 'Connection error: $error',
-              code: 'CONNECTION_ERROR',
-            ),
-          ]),
+        h.controller.addError(
+          ShalomTransportException(
+            message: 'Connection error: $error',
+            code: 'CONNECTION_ERROR',
+          ),
         );
       }
     }
@@ -338,7 +327,7 @@ class WebSocketLink extends GraphQLLink {
 class _OperationHandler {
   final String id;
   final Request request;
-  final StreamController<GraphQLResponse<JsonObject>> controller;
+  final StreamController<Uint8List> controller;
 
   const _OperationHandler({
     required this.id,

--- a/dart/shalom/rust/src/api/runtime.rs
+++ b/dart/shalom/rust/src/api/runtime.rs
@@ -417,13 +417,17 @@ pub async fn listen_requests(
     Ok(())
 }
 
+/// Push a network response for `request_id`. Takes the raw response bytes
+/// (e.g. the exact bytes of an HTTP response body) rather than a JSON
+/// string, so Dart-side transports never need to parse the response into a
+/// `Map` before handing it off — Rust does the JSON parsing.
 #[frb(sync)]
-pub fn push_response(
+pub fn push_response_bytes(
     handle: &RuntimeHandle,
     request_id: u64,
-    response_json: String,
+    response_bytes: Vec<u8>,
 ) -> anyhow::Result<()> {
-    let response = parse_graphql_response(&response_json)?;
+    let response = parse_graphql_response_bytes(&response_bytes)?;
     handle.link.send_response(request_id, response)
 }
 
@@ -493,8 +497,12 @@ fn parse_optional_json(json: Option<String>) -> anyhow::Result<Option<Value>> {
     Ok(Some(value))
 }
 
-fn parse_graphql_response(response_json: &str) -> anyhow::Result<GraphQLResponse> {
-    let value: Value = serde_json::from_str(response_json)?;
+fn parse_graphql_response_bytes(response_bytes: &[u8]) -> anyhow::Result<GraphQLResponse> {
+    let value: Value = serde_json::from_slice(response_bytes)?;
+    graphql_response_from_value(value)
+}
+
+fn graphql_response_from_value(value: Value) -> anyhow::Result<GraphQLResponse> {
     let obj = value
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("graphql response must be a JSON object"))?;

--- a/dart/shalom/rust/src/frb_generated.rs
+++ b/dart/shalom/rust/src/frb_generated.rs
@@ -29,7 +29,7 @@
 use crate::api::runtime::*;
 use crate::api::ws::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
 
 // Section: boilerplate
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -885489623;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -106294496;
 
 // Section: executor
 
@@ -635,14 +635,14 @@ fn wire__crate__api__runtime__observe_fragment_impl(
         },
     )
 }
-fn wire__crate__api__runtime__push_response_impl(
+fn wire__crate__api__runtime__push_response_bytes_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "push_response",
+            debug_name: "push_response_bytes",
             port: None,
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
@@ -660,7 +660,7 @@ fn wire__crate__api__runtime__push_response_impl(
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RuntimeHandle>,
             >>::sse_decode(&mut deserializer);
             let api_request_id = <u64>::sse_decode(&mut deserializer);
-            let api_response_json = <String>::sse_decode(&mut deserializer);
+            let api_response_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                 (move || {
@@ -680,10 +680,10 @@ fn wire__crate__api__runtime__push_response_impl(
                         }
                     }
                     let api_handle_guard = api_handle_guard.unwrap();
-                    let output_ok = crate::api::runtime::push_response(
+                    let output_ok = crate::api::runtime::push_response_bytes(
                         &*api_handle_guard,
                         api_request_id,
-                        api_response_json,
+                        api_response_bytes,
                     )?;
                     Ok(output_ok)
                 })(),
@@ -2304,7 +2304,7 @@ fn pde_ffi_dispatcher_sync_impl(
         7 => wire__crate__api__runtime__get_observer_counts_impl(ptr, rust_vec_len, data_len),
         9 => wire__crate__api__runtime__init_runtime_impl(ptr, rust_vec_len, data_len),
         12 => wire__crate__api__runtime__observe_fragment_impl(ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__runtime__push_response_impl(ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__runtime__push_response_bytes_impl(ptr, rust_vec_len, data_len),
         14 => wire__crate__api__runtime__push_transport_error_impl(ptr, rust_vec_len, data_len),
         15 => wire__crate__api__runtime__read_fragment_impl(ptr, rust_vec_len, data_len),
         16 => wire__crate__api__runtime__read_query_impl(ptr, rust_vec_len, data_len),
@@ -2900,7 +2900,7 @@ mod io {
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate
@@ -2954,7 +2954,7 @@ mod web {
     };
     use flutter_rust_bridge::for_generated::wasm_bindgen;
     use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate

--- a/dart/shalom/test/runtime_test.dart
+++ b/dart/shalom/test/runtime_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:shalom/shalom.dart';
 import 'package:test/test.dart';
@@ -23,16 +25,28 @@ class _MockLink extends GraphQLLink {
     : _queue = Queue.from(responses);
 
   @override
-  Stream<GraphQLResponse<JsonObject>> request({
-    required Request request,
-    HeadersType? headers,
-  }) {
+  Stream<Uint8List> request({required Request request, HeadersType? headers}) {
     if (_queue.isEmpty) {
       throw StateError(
         '_MockLink: no more responses queued for ${request.opName}',
       );
     }
-    return Stream.value(_queue.removeFirst());
+    final response = _queue.removeFirst();
+    switch (response) {
+      case GraphQLData(:final data, :final errors, :final extensions):
+        final payload = <String, dynamic>{'data': data};
+        if (errors != null) payload['errors'] = errors;
+        if (extensions != null) payload['extensions'] = extensions;
+        return Stream.value(utf8.encode(jsonEncode(payload)));
+      case GraphQLError(:final errors, :final extensions):
+        final payload = <String, dynamic>{'errors': errors};
+        if (extensions != null) payload['extensions'] = extensions;
+        return Stream.value(utf8.encode(jsonEncode(payload)));
+      case LinkExceptionResponse(:final errors):
+        return Stream.error(
+          errors.isNotEmpty ? errors.first : StateError('mock link error'),
+        );
+    }
   }
 }
 

--- a/examples/flutter/gif_search/lib/dio_transport.dart
+++ b/examples/flutter/gif_search/lib/dio_transport.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart' as dio;
 import 'package:shalom/shalom.dart';
 
@@ -7,33 +9,37 @@ class DioTransport extends ShalomHttpTransport {
   DioTransport(this.dioClient);
 
   @override
-  Future<JsonObject> request({
+  Future<Uint8List> request({
     required HttpMethod method,
     required String url,
     required JsonObject data,
     HeadersType? headers,
     JsonObject? extra,
   }) async {
-    dio.Response response;
+    dio.Response<List<int>> response;
 
     final headersMap = headers != null
         ? Map.fromEntries(headers.map((e) => MapEntry(e.$1, e.$2)))
         : null;
+    final options = dio.Options(
+      headers: headersMap,
+      responseType: dio.ResponseType.bytes,
+    );
 
     if (method == HttpMethod.GET) {
-      response = await dioClient.get(
+      response = await dioClient.get<List<int>>(
         url,
         data: data,
-        options: dio.Options(headers: headersMap),
+        options: options,
       );
     } else {
-      response = await dioClient.post(
+      response = await dioClient.post<List<int>>(
         url,
         data: data,
-        options: dio.Options(headers: headersMap),
+        options: options,
       );
     }
 
-    return response.data;
+    return Uint8List.fromList(response.data!);
   }
 }


### PR DESCRIPTION
realized that serializing on link level is basically un-avoidable. 
the solution would prob be using a dart dynamic somehow (real dart objects) then we can serialize onetime on dart / rust and thats it.

## Summary by Sourcery

Stream raw GraphQL response bytes from Dart transports into the Rust runtime instead of JSON objects, while keeping a Dart-side client helper for local decoding.

New Features:
- Expose a byte-oriented GraphQLLink interface that returns raw Uint8List response bodies and a parseGraphQLResponseBytes helper for Dart-side decoding.
- Add a Dio-based HTTP transport that requests and returns response bodies as bytes.

Enhancements:
- Refactor ShalomRuntimeClient to push raw response bytes to the Rust runtime, avoiding redundant JSON decode/encode on the Dart side.
- Adjust HTTP and WebSocket links to operate on raw response bytes, delegating JSON parsing and GraphQL response shaping to shared helpers or Rust.
- Update Flutter Rust Bridge bindings and runtime API to support sending and receiving byte lists instead of JSON strings for GraphQL responses.

Tests:
- Adapt runtime tests to the new byte-based GraphQLLink contract via a mock link that serializes responses to JSON bytes.