### PR TITLE
feat: Auto retry + Auto refetch

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -114,6 +114,7 @@ Generated query/subscription APIs usually include:
 - `ClassNameObservable.observe(client)` for lower-level observation.
 - `ClassNameData.readFrom(cache)` for mutation update callbacks.
 - `executionPolicy`, defaulting to `ExecutionPolicyInput.cacheFirst`.
+- `retryDelay` and `autoRefetch` for resilience — see [Retry And Auto-Refetch](#retry-and-auto-refetch).
 
 ## Execution Policy
 
@@ -145,6 +146,21 @@ The widget keeps an active observer for as long as it's in the tree, so GC won't
 
 `@Subscription` uses the same widget shape as `@Query`; the link must support streaming operation results.
 
+## Retry And Auto-Refetch
+
+Generated query/subscription widgets (and `ShalomRuntimeClient.request`) accept two independent, orthogonal knobs for resilience:
+
+- `retryDelay` (a `RetryDelay`) — if the link reports a transport error (e.g. a dropped connection), the error is always emitted on the stream immediately, and if `retryDelay` resolves to a delay, the whole operation is re-issued after it. Defaults to `RetryDelay.inherit()`, which uses the runtime's global default (`runtimeConfig(defaultRetryDelay: ...)`); `RetryDelay.disabled()` turns it off for one call; `RetryDelay.after(duration)` overrides the delay per call. A GraphQL-level error is terminal and never retried — only transport errors are. `ShalomRuntimeClient.mutate` defaults to `RetryDelay.disabled()` since blindly re-sending a mutation after a network blip can duplicate a side effect; opt in explicitly if the mutation is known to be idempotent.
+- `autoRefetch` (a `Duration?`) — independent of any error, re-issues the operation on a plain timer as long as it's still observed. Only meaningful for queries (subscriptions stay open on their own; polling a mutation on a timer doesn't make sense). `null` (the default) means no polling.
+
+```dart
+AlbumsPage(
+  retryDelay: RetryDelay.after(const Duration(seconds: 2)),
+  autoRefetch: const Duration(seconds: 30),
+)
+```
+
+Both stop as soon as the widget/stream is disposed/cancelled — cancellation is checked before each retry/refetch fires, so there's no risk of a stray request landing after the caller stopped listening.
 
 ## Naming Rules
 

--- a/dart/shalom/lib/src/runtime_client.dart
+++ b/dart/shalom/lib/src/runtime_client.dart
@@ -14,6 +14,9 @@ export 'rust/api/runtime.dart'
         RuntimeConfigInput,
         ObserverInfo;
 
+// Note: `RetryDelayInput` (the raw FRB type) is intentionally not exported —
+// callers use the ergonomic [RetryDelay] wrapper instead.
+
 // ---------------------------------------------------------------------------
 // ObservedRefInput helpers (exported so codegen templates can use them via
 // `shalom_core.observedRefInputFromJson(...)`)
@@ -44,9 +47,14 @@ rs_runtime.ObservedRefInput observedRefInputFromJson(JsonObject json) {
 ///   subscriber unsubscribes (e.g. during a widget rebuild or screen
 ///   transition) instead of evicting it on the very next GC sweep. Defaults
 ///   to `Duration.zero` (no grace period).
+/// - [defaultRetryDelay] is the default delay before an operation (query,
+///   mutation, or subscription) that failed with a transport error is
+///   retried. Individual [ShalomRuntimeClient.request] calls can override
+///   this via their `retryDelay` param. Defaults to no auto-retry.
 rs_runtime.RuntimeConfigInput runtimeConfig({
   Duration? gcInterval,
   Duration? retentionGrace,
+  Duration? defaultRetryDelay,
 }) {
   return rs_runtime.RuntimeConfigInput(
     gcIntervalMs: gcInterval != null
@@ -55,7 +63,47 @@ rs_runtime.RuntimeConfigInput runtimeConfig({
     retentionGraceMs: retentionGrace != null
         ? BigInt.from(retentionGrace.inMilliseconds)
         : null,
+    defaultRetryDelayMs: defaultRetryDelay != null
+        ? BigInt.from(defaultRetryDelay.inMilliseconds)
+        : null,
   );
+}
+
+/// Per-call override for [ShalomRuntimeClient.request]'s retry-on-transport-error
+/// behavior. Defaults to [RetryDelay.inherit], which uses the runtime's
+/// globally configured default (see [runtimeConfig]'s `defaultRetryDelay`).
+sealed class RetryDelay {
+  const RetryDelay();
+
+  /// Use the runtime's globally configured default (which may itself be off).
+  const factory RetryDelay.inherit() = _RetryDelayInherit;
+
+  /// Disable auto-retry for this operation, regardless of the global default.
+  const factory RetryDelay.disabled() = _RetryDelayDisabled;
+
+  /// Retry after [duration], overriding the global default.
+  const factory RetryDelay.after(Duration duration) = _RetryDelayAfter;
+
+  rs_runtime.RetryDelayInput _toInput() => switch (this) {
+    _RetryDelayInherit() => const rs_runtime.RetryDelayInput.inherit(),
+    _RetryDelayDisabled() => const rs_runtime.RetryDelayInput.disabled(),
+    _RetryDelayAfter(:final duration) => rs_runtime.RetryDelayInput.millis(
+      BigInt.from(duration.inMilliseconds),
+    ),
+  };
+}
+
+class _RetryDelayInherit extends RetryDelay {
+  const _RetryDelayInherit();
+}
+
+class _RetryDelayDisabled extends RetryDelay {
+  const _RetryDelayDisabled();
+}
+
+class _RetryDelayAfter extends RetryDelay {
+  final Duration duration;
+  const _RetryDelayAfter(this.duration);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,12 +205,19 @@ class ShalomRuntimeClient {
   /// - [GraphQLData<T>] on successful data (may include partial errors)
   /// - [GraphQLError<T>] on GraphQL-level errors
   /// - [LinkExceptionResponse<T>] on transport/network errors
+  ///
+  /// [retryDelay] controls whether a transport error automatically re-issues
+  /// this operation after a delay (the error is still emitted on the stream
+  /// either way). Defaults to [RetryDelay.inherit], i.e. the runtime's global
+  /// default configured via [runtimeConfig]. Retrying stops as soon as the
+  /// returned stream is cancelled.
   Stream<GraphQLResponse<T>> request<T>({
     required String name,
     Map<String, dynamic>? variables,
     required T Function(JsonObject) decoder,
     rs_runtime.ExecutionPolicyInput executionPolicy =
         rs_runtime.ExecutionPolicyInput.networkFirst,
+    RetryDelay retryDelay = const RetryDelay.inherit(),
   }) {
     final variablesJson = variables == null ? null : jsonEncode(variables);
     BigInt? subId;
@@ -176,6 +231,7 @@ class ShalomRuntimeClient {
             name: name,
             variablesJson: variablesJson,
             executionPolicy: executionPolicy,
+            retryDelay: retryDelay._toInput(),
           );
           if (controller.isClosed) {
             if (subId != null) {
@@ -215,15 +271,21 @@ class ShalomRuntimeClient {
   /// result as a one-shot [Future] wrapped in [GraphQLResponse<T>].
   /// The mutation response is written into the shared entity cache, triggering
   /// reactive updates on any query subscriptions that watch the same entities.
+  ///
+  /// Auto-retry is disabled by default (mutations have side effects, so
+  /// silently re-sending one after a transport error is unsafe unless the
+  /// caller opts in explicitly via [retryDelay]).
   Future<GraphQLResponse<T>> mutate<T>({
     required String name,
     Map<String, dynamic>? variables,
     required T Function(JsonObject) decoder,
+    RetryDelay retryDelay = const RetryDelay.disabled(),
   }) => request<T>(
     name: name,
     variables: variables,
     decoder: decoder,
     executionPolicy: rs_runtime.ExecutionPolicyInput.networkFirst,
+    retryDelay: retryDelay,
   ).first;
 
   /// Write [data] to the cache immediately as an optimistic response for the

--- a/dart/shalom/lib/src/runtime_client.dart
+++ b/dart/shalom/lib/src/runtime_client.dart
@@ -211,6 +211,12 @@ class ShalomRuntimeClient {
   /// either way). Defaults to [RetryDelay.inherit], i.e. the runtime's global
   /// default configured via [runtimeConfig]. Retrying stops as soon as the
   /// returned stream is cancelled.
+  ///
+  /// [autoRefetch], if set, re-issues this operation on a timer as long as
+  /// the returned stream is still listened to — a plain polling refetch,
+  /// independent of [retryDelay]'s error handling. Only meaningful for
+  /// queries (subscriptions stay open on their own; mutations shouldn't be
+  /// repeated on a timer).
   Stream<GraphQLResponse<T>> request<T>({
     required String name,
     Map<String, dynamic>? variables,
@@ -218,6 +224,7 @@ class ShalomRuntimeClient {
     rs_runtime.ExecutionPolicyInput executionPolicy =
         rs_runtime.ExecutionPolicyInput.networkFirst,
     RetryDelay retryDelay = const RetryDelay.inherit(),
+    Duration? autoRefetch,
   }) {
     final variablesJson = variables == null ? null : jsonEncode(variables);
     BigInt? subId;
@@ -232,6 +239,9 @@ class ShalomRuntimeClient {
             variablesJson: variablesJson,
             executionPolicy: executionPolicy,
             retryDelay: retryDelay._toInput(),
+            refetchIntervalMs: autoRefetch != null
+                ? BigInt.from(autoRefetch.inMilliseconds)
+                : null,
           );
           if (controller.isClosed) {
             if (subId != null) {

--- a/dart/shalom/lib/src/rust/api/runtime.dart
+++ b/dart/shalom/lib/src/rust/api/runtime.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'runtime.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `cache_value_to_json`, `parse_graphql_response`, `parse_optional_json`, `parse_variables`, `response_to_json`, `to_link_op_type`, `to_observer_info`
+// These functions are ignored because they are not marked as `pub`: `cache_value_to_json`, `parse_graphql_response`, `parse_optional_json`, `parse_variables`, `response_to_json`, `to_observer_info`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `from`, `from`, `from`, `from`
 
 /// Set the global log level filter for all Rust-side logging.
@@ -68,12 +68,14 @@ Future<BigInt> request({
   String? variablesJson,
   required ExecutionPolicyInput executionPolicy,
   required RetryDelayInput retryDelay,
+  BigInt? refetchIntervalMs,
 }) => RustLib.instance.api.crateApiRuntimeRequest(
   handle: handle,
   name: name,
   variablesJson: variablesJson,
   executionPolicy: executionPolicy,
   retryDelay: retryDelay,
+  refetchIntervalMs: refetchIntervalMs,
 );
 
 /// Write `data_json` to the cache as an optimistic response for the mutation

--- a/dart/shalom/lib/src/rust/api/runtime.dart
+++ b/dart/shalom/lib/src/rust/api/runtime.dart
@@ -67,11 +67,13 @@ Future<BigInt> request({
   required String name,
   String? variablesJson,
   required ExecutionPolicyInput executionPolicy,
+  required RetryDelayInput retryDelay,
 }) => RustLib.instance.api.crateApiRuntimeRequest(
   handle: handle,
   name: name,
   variablesJson: variablesJson,
   executionPolicy: executionPolicy,
+  retryDelay: retryDelay,
 );
 
 /// Write `data_json` to the cache as an optimistic response for the mutation
@@ -352,6 +354,20 @@ class ObserverInfo {
           watchedKeys == other.watchedKeys;
 }
 
+@freezed
+sealed class RetryDelayInput with _$RetryDelayInput {
+  const RetryDelayInput._();
+
+  /// Use the runtime's globally configured default (may itself be "off").
+  const factory RetryDelayInput.inherit() = RetryDelayInput_Inherit;
+
+  /// Disable auto-retry for this operation, regardless of the global default.
+  const factory RetryDelayInput.disabled() = RetryDelayInput_Disabled;
+
+  /// Retry after this many milliseconds, overriding the global default.
+  const factory RetryDelayInput.millis(BigInt field0) = RetryDelayInput_Millis;
+}
+
 /// Dart-facing runtime configuration.
 class RuntimeConfigInput {
   /// How often (in milliseconds) the background thread sweeps the cache for
@@ -363,10 +379,22 @@ class RuntimeConfigInput {
   /// becomes eligible for GC eviction. Defaults to 0 (no grace period).
   final BigInt? retentionGraceMs;
 
-  const RuntimeConfigInput({this.gcIntervalMs, this.retentionGraceMs});
+  /// Default delay (in milliseconds) before retrying an operation after a
+  /// transport error, for operations that don't override it via `request`'s
+  /// `retry_delay` param. Defaults to no auto-retry.
+  final BigInt? defaultRetryDelayMs;
+
+  const RuntimeConfigInput({
+    this.gcIntervalMs,
+    this.retentionGraceMs,
+    this.defaultRetryDelayMs,
+  });
 
   @override
-  int get hashCode => gcIntervalMs.hashCode ^ retentionGraceMs.hashCode;
+  int get hashCode =>
+      gcIntervalMs.hashCode ^
+      retentionGraceMs.hashCode ^
+      defaultRetryDelayMs.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -374,7 +402,8 @@ class RuntimeConfigInput {
       other is RuntimeConfigInput &&
           runtimeType == other.runtimeType &&
           gcIntervalMs == other.gcIntervalMs &&
-          retentionGraceMs == other.retentionGraceMs;
+          retentionGraceMs == other.retentionGraceMs &&
+          defaultRetryDelayMs == other.defaultRetryDelayMs;
 }
 
 @freezed

--- a/dart/shalom/lib/src/rust/api/runtime.freezed.dart
+++ b/dart/shalom/lib/src/rust/api/runtime.freezed.dart
@@ -12,6 +12,302 @@ part of 'runtime.dart';
 // dart format off
 T _$identity<T>(T value) => value;
 /// @nodoc
+mixin _$RetryDelayInput {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RetryDelayInput);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'RetryDelayInput()';
+}
+
+
+}
+
+/// @nodoc
+class $RetryDelayInputCopyWith<$Res>  {
+$RetryDelayInputCopyWith(RetryDelayInput _, $Res Function(RetryDelayInput) __);
+}
+
+
+/// Adds pattern-matching-related methods to [RetryDelayInput].
+extension RetryDelayInputPatterns on RetryDelayInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RetryDelayInput_Inherit value)?  inherit,TResult Function( RetryDelayInput_Disabled value)?  disabled,TResult Function( RetryDelayInput_Millis value)?  millis,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case RetryDelayInput_Inherit() when inherit != null:
+return inherit(_that);case RetryDelayInput_Disabled() when disabled != null:
+return disabled(_that);case RetryDelayInput_Millis() when millis != null:
+return millis(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RetryDelayInput_Inherit value)  inherit,required TResult Function( RetryDelayInput_Disabled value)  disabled,required TResult Function( RetryDelayInput_Millis value)  millis,}){
+final _that = this;
+switch (_that) {
+case RetryDelayInput_Inherit():
+return inherit(_that);case RetryDelayInput_Disabled():
+return disabled(_that);case RetryDelayInput_Millis():
+return millis(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RetryDelayInput_Inherit value)?  inherit,TResult? Function( RetryDelayInput_Disabled value)?  disabled,TResult? Function( RetryDelayInput_Millis value)?  millis,}){
+final _that = this;
+switch (_that) {
+case RetryDelayInput_Inherit() when inherit != null:
+return inherit(_that);case RetryDelayInput_Disabled() when disabled != null:
+return disabled(_that);case RetryDelayInput_Millis() when millis != null:
+return millis(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  inherit,TResult Function()?  disabled,TResult Function( BigInt field0)?  millis,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case RetryDelayInput_Inherit() when inherit != null:
+return inherit();case RetryDelayInput_Disabled() when disabled != null:
+return disabled();case RetryDelayInput_Millis() when millis != null:
+return millis(_that.field0);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  inherit,required TResult Function()  disabled,required TResult Function( BigInt field0)  millis,}) {final _that = this;
+switch (_that) {
+case RetryDelayInput_Inherit():
+return inherit();case RetryDelayInput_Disabled():
+return disabled();case RetryDelayInput_Millis():
+return millis(_that.field0);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  inherit,TResult? Function()?  disabled,TResult? Function( BigInt field0)?  millis,}) {final _that = this;
+switch (_that) {
+case RetryDelayInput_Inherit() when inherit != null:
+return inherit();case RetryDelayInput_Disabled() when disabled != null:
+return disabled();case RetryDelayInput_Millis() when millis != null:
+return millis(_that.field0);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class RetryDelayInput_Inherit extends RetryDelayInput {
+  const RetryDelayInput_Inherit(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RetryDelayInput_Inherit);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'RetryDelayInput.inherit()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class RetryDelayInput_Disabled extends RetryDelayInput {
+  const RetryDelayInput_Disabled(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RetryDelayInput_Disabled);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'RetryDelayInput.disabled()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class RetryDelayInput_Millis extends RetryDelayInput {
+  const RetryDelayInput_Millis(this.field0): super._();
+  
+
+ final  BigInt field0;
+
+/// Create a copy of RetryDelayInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RetryDelayInput_MillisCopyWith<RetryDelayInput_Millis> get copyWith => _$RetryDelayInput_MillisCopyWithImpl<RetryDelayInput_Millis>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RetryDelayInput_Millis&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'RetryDelayInput.millis(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RetryDelayInput_MillisCopyWith<$Res> implements $RetryDelayInputCopyWith<$Res> {
+  factory $RetryDelayInput_MillisCopyWith(RetryDelayInput_Millis value, $Res Function(RetryDelayInput_Millis) _then) = _$RetryDelayInput_MillisCopyWithImpl;
+@useResult
+$Res call({
+ BigInt field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$RetryDelayInput_MillisCopyWithImpl<$Res>
+    implements $RetryDelayInput_MillisCopyWith<$Res> {
+  _$RetryDelayInput_MillisCopyWithImpl(this._self, this._then);
+
+  final RetryDelayInput_Millis _self;
+  final $Res Function(RetryDelayInput_Millis) _then;
+
+/// Create a copy of RetryDelayInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(RetryDelayInput_Millis(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as BigInt,
+  ));
+}
+
+
+}
+
+/// @nodoc
 mixin _$SubscriptionEvent {
 
 

--- a/dart/shalom/lib/src/rust/frb_generated.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.dart
@@ -180,6 +180,7 @@ abstract class RustLibApi extends BaseApi {
     String? variablesJson,
     required ExecutionPolicyInput executionPolicy,
     required RetryDelayInput retryDelay,
+    BigInt? refetchIntervalMs,
   });
 
   Future<void> crateApiRuntimeRollbackOptimistic({
@@ -1000,6 +1001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     String? variablesJson,
     required ExecutionPolicyInput executionPolicy,
     required RetryDelayInput retryDelay,
+    BigInt? refetchIntervalMs,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1013,6 +1015,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_String(variablesJson, serializer);
           sse_encode_execution_policy_input(executionPolicy, serializer);
           sse_encode_box_autoadd_retry_delay_input(retryDelay, serializer);
+          sse_encode_opt_box_autoadd_u_64(refetchIntervalMs, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1025,7 +1028,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiRuntimeRequestConstMeta,
-        argValues: [handle, name, variablesJson, executionPolicy, retryDelay],
+        argValues: [
+          handle,
+          name,
+          variablesJson,
+          executionPolicy,
+          retryDelay,
+          refetchIntervalMs,
+        ],
         apiImpl: this,
       ),
     );
@@ -1039,6 +1049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       "variablesJson",
       "executionPolicy",
       "retryDelay",
+      "refetchIntervalMs",
     ],
   );
 

--- a/dart/shalom/lib/src/rust/frb_generated.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.dart
@@ -179,6 +179,7 @@ abstract class RustLibApi extends BaseApi {
     required String name,
     String? variablesJson,
     required ExecutionPolicyInput executionPolicy,
+    required RetryDelayInput retryDelay,
   });
 
   Future<void> crateApiRuntimeRollbackOptimistic({
@@ -998,6 +999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String name,
     String? variablesJson,
     required ExecutionPolicyInput executionPolicy,
+    required RetryDelayInput retryDelay,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1010,6 +1012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(name, serializer);
           sse_encode_opt_String(variablesJson, serializer);
           sse_encode_execution_policy_input(executionPolicy, serializer);
+          sse_encode_box_autoadd_retry_delay_input(retryDelay, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1022,7 +1025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateApiRuntimeRequestConstMeta,
-        argValues: [handle, name, variablesJson, executionPolicy],
+        argValues: [handle, name, variablesJson, executionPolicy, retryDelay],
         apiImpl: this,
       ),
     );
@@ -1030,7 +1033,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiRuntimeRequestConstMeta => const TaskConstMeta(
     debugName: "request",
-    argNames: ["handle", "name", "variablesJson", "executionPolicy"],
+    argNames: [
+      "handle",
+      "name",
+      "variablesJson",
+      "executionPolicy",
+      "retryDelay",
+    ],
   );
 
   @override
@@ -1637,6 +1646,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RetryDelayInput dco_decode_box_autoadd_retry_delay_input(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_retry_delay_input(raw);
+  }
+
+  @protected
   RuntimeConfigInput dco_decode_box_autoadd_runtime_config_input(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_runtime_config_input(raw);
@@ -1742,14 +1757,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RetryDelayInput dco_decode_retry_delay_input(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return RetryDelayInput_Inherit();
+      case 1:
+        return RetryDelayInput_Disabled();
+      case 2:
+        return RetryDelayInput_Millis(dco_decode_u_64(raw[1]));
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   RuntimeConfigInput dco_decode_runtime_config_input(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return RuntimeConfigInput(
       gcIntervalMs: dco_decode_opt_box_autoadd_u_64(arr[0]),
       retentionGraceMs: dco_decode_opt_box_autoadd_u_64(arr[1]),
+      defaultRetryDelayMs: dco_decode_opt_box_autoadd_u_64(arr[2]),
     );
   }
 
@@ -1962,6 +1993,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RetryDelayInput sse_decode_box_autoadd_retry_delay_input(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_retry_delay_input(deserializer));
+  }
+
+  @protected
   RuntimeConfigInput sse_decode_box_autoadd_runtime_config_input(
     SseDeserializer deserializer,
   ) {
@@ -2109,15 +2148,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  RetryDelayInput sse_decode_retry_delay_input(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return RetryDelayInput_Inherit();
+      case 1:
+        return RetryDelayInput_Disabled();
+      case 2:
+        var var_field0 = sse_decode_u_64(deserializer);
+        return RetryDelayInput_Millis(var_field0);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   RuntimeConfigInput sse_decode_runtime_config_input(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_gcIntervalMs = sse_decode_opt_box_autoadd_u_64(deserializer);
     var var_retentionGraceMs = sse_decode_opt_box_autoadd_u_64(deserializer);
+    var var_defaultRetryDelayMs = sse_decode_opt_box_autoadd_u_64(deserializer);
     return RuntimeConfigInput(
       gcIntervalMs: var_gcIntervalMs,
       retentionGraceMs: var_retentionGraceMs,
+      defaultRetryDelayMs: var_defaultRetryDelayMs,
     );
   }
 
@@ -2372,6 +2431,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_retry_delay_input(
+    RetryDelayInput self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_retry_delay_input(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_runtime_config_input(
     RuntimeConfigInput self,
     SseSerializer serializer,
@@ -2506,6 +2574,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_retry_delay_input(
+    RetryDelayInput self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case RetryDelayInput_Inherit():
+        sse_encode_i_32(0, serializer);
+      case RetryDelayInput_Disabled():
+        sse_encode_i_32(1, serializer);
+      case RetryDelayInput_Millis(field0: final field0):
+        sse_encode_i_32(2, serializer);
+        sse_encode_u_64(field0, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_runtime_config_input(
     RuntimeConfigInput self,
     SseSerializer serializer,
@@ -2513,6 +2598,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_opt_box_autoadd_u_64(self.gcIntervalMs, serializer);
     sse_encode_opt_box_autoadd_u_64(self.retentionGraceMs, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.defaultRetryDelayMs, serializer);
   }
 
   @protected

--- a/dart/shalom/lib/src/rust/frb_generated.io.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.io.dart
@@ -89,6 +89,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ObservedRefInput dco_decode_box_autoadd_observed_ref_input(dynamic raw);
 
   @protected
+  RetryDelayInput dco_decode_box_autoadd_retry_delay_input(dynamic raw);
+
+  @protected
   RuntimeConfigInput dco_decode_box_autoadd_runtime_config_input(dynamic raw);
 
   @protected
@@ -131,6 +134,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt? dco_decode_opt_box_autoadd_u_64(dynamic raw);
+
+  @protected
+  RetryDelayInput dco_decode_retry_delay_input(dynamic raw);
 
   @protected
   RuntimeConfigInput dco_decode_runtime_config_input(dynamic raw);
@@ -222,6 +228,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RetryDelayInput sse_decode_box_autoadd_retry_delay_input(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RuntimeConfigInput sse_decode_box_autoadd_runtime_config_input(
     SseDeserializer deserializer,
   );
@@ -270,6 +281,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt? sse_decode_opt_box_autoadd_u_64(SseDeserializer deserializer);
+
+  @protected
+  RetryDelayInput sse_decode_retry_delay_input(SseDeserializer deserializer);
 
   @protected
   RuntimeConfigInput sse_decode_runtime_config_input(
@@ -377,6 +391,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_retry_delay_input(
+    RetryDelayInput self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_runtime_config_input(
     RuntimeConfigInput self,
     SseSerializer serializer,
@@ -438,6 +458,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_u_64(BigInt? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_retry_delay_input(
+    RetryDelayInput self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_runtime_config_input(

--- a/dart/shalom/lib/src/rust/frb_generated.web.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.web.dart
@@ -91,6 +91,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ObservedRefInput dco_decode_box_autoadd_observed_ref_input(dynamic raw);
 
   @protected
+  RetryDelayInput dco_decode_box_autoadd_retry_delay_input(dynamic raw);
+
+  @protected
   RuntimeConfigInput dco_decode_box_autoadd_runtime_config_input(dynamic raw);
 
   @protected
@@ -133,6 +136,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt? dco_decode_opt_box_autoadd_u_64(dynamic raw);
+
+  @protected
+  RetryDelayInput dco_decode_retry_delay_input(dynamic raw);
 
   @protected
   RuntimeConfigInput dco_decode_runtime_config_input(dynamic raw);
@@ -224,6 +230,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RetryDelayInput sse_decode_box_autoadd_retry_delay_input(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   RuntimeConfigInput sse_decode_box_autoadd_runtime_config_input(
     SseDeserializer deserializer,
   );
@@ -272,6 +283,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt? sse_decode_opt_box_autoadd_u_64(SseDeserializer deserializer);
+
+  @protected
+  RetryDelayInput sse_decode_retry_delay_input(SseDeserializer deserializer);
 
   @protected
   RuntimeConfigInput sse_decode_runtime_config_input(
@@ -379,6 +393,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_retry_delay_input(
+    RetryDelayInput self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_runtime_config_input(
     RuntimeConfigInput self,
     SseSerializer serializer,
@@ -440,6 +460,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_u_64(BigInt? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_retry_delay_input(
+    RetryDelayInput self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_runtime_config_input(

--- a/dart/shalom/rust/src/api/runtime.rs
+++ b/dart/shalom/rust/src/api/runtime.rs
@@ -217,6 +217,7 @@ pub async fn request(
     variables_json: Option<String>,
     execution_policy: ExecutionPolicyInput,
     retry_delay: RetryDelayInput,
+    refetch_interval_ms: Option<u64>,
 ) -> anyhow::Result<u64> {
     let variables = parse_variables(variables_json)?;
     let op_ctx = handle.runtime.operation_by_name(&name)?;
@@ -226,6 +227,7 @@ pub async fn request(
         RetryDelayInput::Disabled => None,
         RetryDelayInput::Millis(ms) => Some(std::time::Duration::from_millis(ms)),
     };
+    let refetch_interval = refetch_interval_ms.map(std::time::Duration::from_millis);
 
     let sub_id = handle.runtime.execute_operation(
         op_ctx,
@@ -233,6 +235,7 @@ pub async fn request(
         execution_policy.into(),
         handle.link.clone(),
         retry_delay,
+        refetch_interval,
     );
 
     Ok(sub_id.into())

--- a/dart/shalom/rust/src/api/runtime.rs
+++ b/dart/shalom/rust/src/api/runtime.rs
@@ -5,9 +5,7 @@ use flutter_rust_bridge::frb;
 use tokio_stream::StreamExt;
 
 use shalom_runtime::sansio_protocols::host::HostLink;
-use shalom_runtime::sansio_protocols::{
-    GraphQLLink, GraphQLResponse, OperationType as LinkOperationType, Request,
-};
+use shalom_runtime::sansio_protocols::GraphQLResponse;
 use shalom_runtime::{
     ExecutionPolicy, ObservedRef, OptimisticWriteId, RuntimeConfig, RuntimeResponse, ShalomRuntime,
     SubscriptionError, SubscriptionId,
@@ -38,6 +36,10 @@ pub struct RuntimeConfigInput {
     /// subscriber after its last real subscriber unsubscribes, before it
     /// becomes eligible for GC eviction. Defaults to 0 (no grace period).
     pub retention_grace_ms: Option<u64>,
+    /// Default delay (in milliseconds) before retrying an operation after a
+    /// transport error, for operations that don't override it via `request`'s
+    /// `retry_delay` param. Defaults to no auto-retry.
+    pub default_retry_delay_ms: Option<u64>,
 }
 
 impl From<RuntimeConfigInput> for RuntimeConfig {
@@ -52,8 +54,24 @@ impl From<RuntimeConfigInput> for RuntimeConfig {
                 .retention_grace_ms
                 .map(std::time::Duration::from_millis)
                 .unwrap_or(default.retention_grace),
+            default_retry_delay: value
+                .default_retry_delay_ms
+                .map(std::time::Duration::from_millis)
+                .or(default.default_retry_delay),
         }
     }
+}
+
+/// Per-call override for an operation's retry-on-transport-error delay.
+/// Passed to `request`; defaults to `Inherit` (use `RuntimeConfig::default_retry_delay`).
+#[frb]
+pub enum RetryDelayInput {
+    /// Use the runtime's globally configured default (may itself be "off").
+    Inherit,
+    /// Disable auto-retry for this operation, regardless of the global default.
+    Disabled,
+    /// Retry after this many milliseconds, overriding the global default.
+    Millis(u64),
 }
 
 #[frb]
@@ -198,69 +216,24 @@ pub async fn request(
     name: String,
     variables_json: Option<String>,
     execution_policy: ExecutionPolicyInput,
+    retry_delay: RetryDelayInput,
 ) -> anyhow::Result<u64> {
     let variables = parse_variables(variables_json)?;
     let op_ctx = handle.runtime.operation_by_name(&name)?;
-    let sub_id = handle.runtime.create_operation_subscription(
-        op_ctx.clone(),
-        variables.clone(),
+
+    let retry_delay = match retry_delay {
+        RetryDelayInput::Inherit => handle.runtime.default_retry_delay(),
+        RetryDelayInput::Disabled => None,
+        RetryDelayInput::Millis(ms) => Some(std::time::Duration::from_millis(ms)),
+    };
+
+    let sub_id = handle.runtime.execute_operation(
+        op_ctx,
+        variables,
         execution_policy.into(),
+        handle.link.clone(),
+        retry_delay,
     );
-
-    // Spawn a task to drive the network round-trip and normalise the response.
-    // The normalisation side-effect triggers `notify_subscribers` which pushes
-    // data onto the subscription channel opened above.
-    let link = handle.link.clone();
-    let runtime = handle.runtime.clone();
-
-    tokio::spawn(async move {
-        let request = Request {
-            query: op_ctx.query.clone(),
-            variables: variables.clone().unwrap_or_default(),
-            operation_name: op_ctx.get_operation_name().to_string(),
-            operation_type: to_link_op_type(op_ctx.op_type()),
-            headers: None,
-        };
-
-        let mut stream = link.execute(request);
-        while let Some(response) = stream.next().await {
-            match response {
-                GraphQLResponse::Data { data, .. } => {
-                    if let Err(e) =
-                        runtime.normalize(&op_ctx, Value::Object(data), variables.as_ref())
-                    {
-                        runtime.push_subscription_error(
-                            sub_id,
-                            SubscriptionError::Transport {
-                                message: e.to_string(),
-                                code: "NORMALIZATION_ERROR".into(),
-                                details: None,
-                            },
-                        );
-                        break;
-                    }
-                }
-                GraphQLResponse::Error { errors, extensions } => {
-                    runtime.push_subscription_error(
-                        sub_id,
-                        SubscriptionError::GraphQL { errors, extensions },
-                    );
-                    break;
-                }
-                GraphQLResponse::TransportError(err) => {
-                    runtime.push_subscription_error(
-                        sub_id,
-                        SubscriptionError::Transport {
-                            message: err.message,
-                            code: err.code,
-                            details: err.details,
-                        },
-                    );
-                    break;
-                }
-            }
-        }
-    });
 
     Ok(sub_id.into())
 }
@@ -454,16 +427,6 @@ pub async fn complete_transport(handle: &RuntimeHandle, request_id: u64) {
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
-
-fn to_link_op_type(op_type: shalom_core::operation::types::OperationType) -> LinkOperationType {
-    match op_type {
-        shalom_core::operation::types::OperationType::Query => LinkOperationType::Query,
-        shalom_core::operation::types::OperationType::Mutation => LinkOperationType::Mutation,
-        shalom_core::operation::types::OperationType::Subscription => {
-            LinkOperationType::Subscription
-        }
-    }
-}
 
 fn parse_variables(variables_json: Option<String>) -> anyhow::Result<Option<Map<String, Value>>> {
     let json = match variables_json {

--- a/dart/shalom/rust/src/api/runtime.rs
+++ b/dart/shalom/rust/src/api/runtime.rs
@@ -4,8 +4,8 @@ use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
 use tokio_stream::StreamExt;
 
-use shalom_runtime::sansio_protocols::host::HostLink;
 use shalom_runtime::sansio_protocols::GraphQLResponse;
+use shalom_runtime::sansio_protocols::host::HostLink;
 use shalom_runtime::{
     ExecutionPolicy, ObservedRef, OptimisticWriteId, RuntimeConfig, RuntimeResponse, ShalomRuntime,
     SubscriptionError, SubscriptionId,

--- a/dart/shalom/rust/src/frb_generated.rs
+++ b/dart/shalom/rust/src/frb_generated.rs
@@ -29,7 +29,7 @@
 use crate::api::runtime::*;
 use crate::api::ws::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
+use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
 
 // Section: boilerplate
@@ -3137,7 +3137,7 @@ mod io {
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
-    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
+    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate
@@ -3191,7 +3191,7 @@ mod web {
     };
     use flutter_rust_bridge::for_generated::wasm_bindgen;
     use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
+    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate

--- a/dart/shalom/rust/src/frb_generated.rs
+++ b/dart/shalom/rust/src/frb_generated.rs
@@ -1215,6 +1215,7 @@ fn wire__crate__api__runtime__request_impl(
                 <crate::api::runtime::ExecutionPolicyInput>::sse_decode(&mut deserializer);
             let api_retry_delay =
                 <crate::api::runtime::RetryDelayInput>::sse_decode(&mut deserializer);
+            let api_refetch_interval_ms = <Option<u64>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -1244,6 +1245,7 @@ fn wire__crate__api__runtime__request_impl(
                             api_variables_json,
                             api_execution_policy,
                             api_retry_delay,
+                            api_refetch_interval_ms,
                         )
                         .await?;
                         Ok(output_ok)

--- a/dart/shalom/rust/src/frb_generated.rs
+++ b/dart/shalom/rust/src/frb_generated.rs
@@ -29,7 +29,7 @@
 use crate::api::runtime::*;
 use crate::api::ws::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
 
 // Section: boilerplate
@@ -1213,6 +1213,8 @@ fn wire__crate__api__runtime__request_impl(
             let api_variables_json = <Option<String>>::sse_decode(&mut deserializer);
             let api_execution_policy =
                 <crate::api::runtime::ExecutionPolicyInput>::sse_decode(&mut deserializer);
+            let api_retry_delay =
+                <crate::api::runtime::RetryDelayInput>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -1241,6 +1243,7 @@ fn wire__crate__api__runtime__request_impl(
                             api_name,
                             api_variables_json,
                             api_execution_policy,
+                            api_retry_delay,
                         )
                         .await?;
                         Ok(output_ok)
@@ -2297,14 +2300,38 @@ impl SseDecode for Option<u64> {
     }
 }
 
+impl SseDecode for crate::api::runtime::RetryDelayInput {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::runtime::RetryDelayInput::Inherit;
+            }
+            1 => {
+                return crate::api::runtime::RetryDelayInput::Disabled;
+            }
+            2 => {
+                let mut var_field0 = <u64>::sse_decode(deserializer);
+                return crate::api::runtime::RetryDelayInput::Millis(var_field0);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::api::runtime::RuntimeConfigInput {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_gcIntervalMs = <Option<u64>>::sse_decode(deserializer);
         let mut var_retentionGraceMs = <Option<u64>>::sse_decode(deserializer);
+        let mut var_defaultRetryDelayMs = <Option<u64>>::sse_decode(deserializer);
         return crate::api::runtime::RuntimeConfigInput {
             gc_interval_ms: var_gcIntervalMs,
             retention_grace_ms: var_retentionGraceMs,
+            default_retry_delay_ms: var_defaultRetryDelayMs,
         };
     }
 }
@@ -2614,11 +2641,38 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::runtime::ObserverInfo>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::runtime::RetryDelayInput {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::runtime::RetryDelayInput::Inherit => [0.into_dart()].into_dart(),
+            crate::api::runtime::RetryDelayInput::Disabled => [1.into_dart()].into_dart(),
+            crate::api::runtime::RetryDelayInput::Millis(field0) => {
+                [2.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::runtime::RetryDelayInput
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::runtime::RetryDelayInput>
+    for crate::api::runtime::RetryDelayInput
+{
+    fn into_into_dart(self) -> crate::api::runtime::RetryDelayInput {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::runtime::RuntimeConfigInput {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.gc_interval_ms.into_into_dart().into_dart(),
             self.retention_grace_ms.into_into_dart().into_dart(),
+            self.default_retry_delay_ms.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -2932,11 +2986,33 @@ impl SseEncode for Option<u64> {
     }
 }
 
+impl SseEncode for crate::api::runtime::RetryDelayInput {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::runtime::RetryDelayInput::Inherit => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::runtime::RetryDelayInput::Disabled => {
+                <i32>::sse_encode(1, serializer);
+            }
+            crate::api::runtime::RetryDelayInput::Millis(field0) => {
+                <i32>::sse_encode(2, serializer);
+                <u64>::sse_encode(field0, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::api::runtime::RuntimeConfigInput {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Option<u64>>::sse_encode(self.gc_interval_ms, serializer);
         <Option<u64>>::sse_encode(self.retention_grace_ms, serializer);
+        <Option<u64>>::sse_encode(self.default_retry_delay_ms, serializer);
     }
 }
 
@@ -3061,7 +3137,7 @@ mod io {
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate
@@ -3115,7 +3191,7 @@ mod web {
     };
     use flutter_rust_bridge::for_generated::wasm_bindgen;
     use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate

--- a/examples/flutter/gif_search/lib/__graphql__/AddGifToAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AddGifToAlbumMutation.mutation.shalom.dart
@@ -48,13 +48,13 @@ abstract class $AddGifToAlbumMutation {
   /// ```dart
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
-  ///   update: (cache, data) {
-  ///     final current = cache.readQuery(
+  ///   update: (cache, data) async {
+  ///     final current = await cache.readQuery(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       cache.writeQuery(
+  ///       await cache.writeQuery(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/__graphql__/AlbumGifSearch.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AlbumGifSearch.shalom.dart
@@ -222,6 +222,8 @@ final class AlbumGifSearchData implements shalom_core.OperationInterface {
 
 final class AlbumGifSearchObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final AlbumGifSearchVariables variables;
 
@@ -229,6 +231,8 @@ final class AlbumGifSearchObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'AlbumGifSearch';
@@ -243,6 +247,8 @@ final class AlbumGifSearchObservable {
 
       decoder: AlbumGifSearchData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/examples/flutter/gif_search/lib/__graphql__/AlbumGifSearch.widget.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AlbumGifSearch.widget.shalom.dart
@@ -13,12 +13,16 @@ abstract class $AlbumGifSearch extends StatefulWidget {
   String operation$Name() => 'AlbumGifSearch';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final AlbumGifSearchVariables variables;
   const $AlbumGifSearch({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -66,6 +70,8 @@ class _$AlbumGifSearchState extends State<$AlbumGifSearch> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/examples/flutter/gif_search/lib/__graphql__/AlbumsPage.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AlbumsPage.shalom.dart
@@ -186,9 +186,13 @@ final class AlbumsPageData implements shalom_core.OperationInterface {
 
 final class AlbumsPageObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   const AlbumsPageObservable({
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'AlbumsPage';
@@ -201,6 +205,8 @@ final class AlbumsPageObservable {
 
       decoder: AlbumsPageData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/examples/flutter/gif_search/lib/__graphql__/AlbumsPage.widget.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AlbumsPage.widget.shalom.dart
@@ -15,8 +15,15 @@ abstract class $AlbumsPage extends StatefulWidget {
   String operation$Name() => 'AlbumsPage';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
-  const $AlbumsPage({super.key, this.executionPolicy = .cacheFirst});
+  const $AlbumsPage({
+    super.key,
+    this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
+  });
 
   Widget buildLoading(BuildContext context);
   Widget buildError(BuildContext context, Object error);
@@ -57,25 +64,30 @@ class _$AlbumsPageState extends State<$AlbumsPage> {
   void _subscribe() {
     _sub?.cancel();
     final client = ShalomScope.of(context);
-    _sub = AlbumsPageObservable(executionPolicy: widget.executionPolicy)
-        .observe(client)
-        .listen(
-          (response) {
-            setState(() {
-              switch (response) {
-                case shalom_core.GraphQLData(data: final data):
-                  _data = data;
-                  _error = null;
-                case shalom_core.GraphQLError() ||
-                    shalom_core.LinkExceptionResponse():
-                  _error = response;
-              }
-            });
-          },
-          onDone: () {
-            if (mounted) _subscribe();
-          },
-        );
+    _sub =
+        AlbumsPageObservable(
+              executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
+            )
+            .observe(client)
+            .listen(
+              (response) {
+                setState(() {
+                  switch (response) {
+                    case shalom_core.GraphQLData(data: final data):
+                      _data = data;
+                      _error = null;
+                    case shalom_core.GraphQLError() ||
+                        shalom_core.LinkExceptionResponse():
+                      _error = response;
+                  }
+                });
+              },
+              onDone: () {
+                if (mounted) _subscribe();
+              },
+            );
   }
 
   @override

--- a/examples/flutter/gif_search/lib/__graphql__/CreateAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/CreateAlbumMutation.mutation.shalom.dart
@@ -40,13 +40,13 @@ abstract class $CreateAlbumMutation {
   /// ```dart
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
-  ///   update: (cache, data) {
-  ///     final current = cache.readQuery(
+  ///   update: (cache, data) async {
+  ///     final current = await cache.readQuery(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       cache.writeQuery(
+  ///       await cache.writeQuery(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/__graphql__/DeleteAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/DeleteAlbumMutation.mutation.shalom.dart
@@ -40,13 +40,13 @@ abstract class $DeleteAlbumMutation {
   /// ```dart
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
-  ///   update: (cache, data) {
-  ///     final current = cache.readQuery(
+  ///   update: (cache, data) async {
+  ///     final current = await cache.readQuery(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       cache.writeQuery(
+  ///       await cache.writeQuery(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/__graphql__/RemoveGifFromAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/RemoveGifFromAlbumMutation.mutation.shalom.dart
@@ -44,13 +44,13 @@ abstract class $RemoveGifFromAlbumMutation {
   /// ```dart
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
-  ///   update: (cache, data) {
-  ///     final current = cache.readQuery(
+  ///   update: (cache, data) async {
+  ///     final current = await cache.readQuery(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       cache.writeQuery(
+  ///       await cache.writeQuery(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/main.dart
+++ b/examples/flutter/gif_search/lib/main.dart
@@ -127,7 +127,7 @@ class _AppWithDebugPanel extends StatelessWidget {
   }
 """)
 class AlbumsPage extends $AlbumsPage with QueryWidgetMixin {
-  const AlbumsPage({super.key});
+  const AlbumsPage({super.key, super.autoRefetch = const Duration(seconds: 5)});
 
   @override
   Widget buildData(BuildContext context, AlbumsPageData data) {
@@ -320,7 +320,7 @@ class DeleteAlbumMutation extends $DeleteAlbumMutation {
 @Mutation(r"""
   ($name: String!) {
     createAlbum(name: $name) {
-      id 
+      id
       name
       tag
       gifs {
@@ -617,7 +617,9 @@ class _AlbumDetailPageState extends State<_AlbumDetailPage> {
             gifId: gifId,
             update: (shalom.CacheProxy cache, data) async {
               if (data.removeGifFromAlbum != null) return;
-              final current = await AlbumWidgetRef.fromId(widget.albumId).readFrom(cache);
+              final current = await AlbumWidgetRef.fromId(
+                widget.albumId,
+              ).readFrom(cache);
               if (current == null) return;
               await cache.writeFragment(
                 data: AlbumWidgetData(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.shalom.dart
@@ -151,6 +151,8 @@ final class UserCardQueryData implements shalom_core.OperationInterface {
 
 final class UserCardQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final UserCardQueryVariables variables;
 
@@ -158,6 +160,8 @@ final class UserCardQueryObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'UserCardQuery';
@@ -172,6 +176,8 @@ final class UserCardQueryObservable {
 
       decoder: UserCardQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
@@ -15,12 +15,16 @@ abstract class $UserCardQuery extends StatefulWidget {
   String operation$Name() => 'UserCardQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final UserCardQueryVariables variables;
   const $UserCardQuery({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -68,6 +72,8 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.shalom.dart
@@ -141,6 +141,8 @@ final class PetQueryData implements shalom_core.OperationInterface {
 
 final class PetQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final PetQueryVariables variables;
 
@@ -148,6 +150,8 @@ final class PetQueryObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'PetQuery';
@@ -162,6 +166,8 @@ final class PetQueryObservable {
 
       decoder: PetQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
@@ -14,12 +14,16 @@ abstract class $PetQuery extends StatefulWidget {
   String operation$Name() => 'PetQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final PetQueryVariables variables;
   const $PetQuery({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -67,6 +71,8 @@ class _$PetQueryState extends State<$PetQuery> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.shalom.dart
@@ -174,6 +174,8 @@ final class ZooAnimalsQueryData implements shalom_core.OperationInterface {
 
 final class ZooAnimalsQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final ZooAnimalsQueryVariables variables;
 
@@ -181,6 +183,8 @@ final class ZooAnimalsQueryObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'ZooAnimalsQuery';
@@ -195,6 +199,8 @@ final class ZooAnimalsQueryObservable {
 
       decoder: ZooAnimalsQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
@@ -14,12 +14,16 @@ abstract class $ZooAnimalsQuery extends StatefulWidget {
   String operation$Name() => 'ZooAnimalsQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final ZooAnimalsQueryVariables variables;
   const $ZooAnimalsQuery({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -67,6 +71,8 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.shalom.dart
@@ -156,6 +156,8 @@ final class ZooQueryData implements shalom_core.OperationInterface {
 
 final class ZooQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final ZooQueryVariables variables;
 
@@ -163,6 +165,8 @@ final class ZooQueryObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'ZooQuery';
@@ -177,6 +181,8 @@ final class ZooQueryObservable {
 
       decoder: ZooQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
@@ -14,12 +14,16 @@ abstract class $ZooQuery extends StatefulWidget {
   String operation$Name() => 'ZooQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final ZooQueryVariables variables;
   const $ZooQuery({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -67,6 +71,8 @@ class _$ZooQueryState extends State<$ZooQuery> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.shalom.dart
@@ -130,6 +130,8 @@ final class UserWidgetData implements shalom_core.OperationInterface {
 
 final class UserWidgetObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final UserWidgetVariables variables;
 
@@ -137,6 +139,8 @@ final class UserWidgetObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'UserWidget';
@@ -151,6 +155,8 @@ final class UserWidgetObservable {
 
       decoder: UserWidgetData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
@@ -13,12 +13,16 @@ abstract class $UserWidget extends StatefulWidget {
   String operation$Name() => 'UserWidget';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final UserWidgetVariables variables;
   const $UserWidget({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -66,6 +70,8 @@ class _$UserWidgetState extends State<$UserWidget> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart
@@ -268,9 +268,13 @@ final class ZooAnimalsContractQueryData
 
 final class ZooAnimalsContractQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   const ZooAnimalsContractQueryObservable({
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'ZooAnimalsContractQuery';
@@ -283,6 +287,8 @@ final class ZooAnimalsContractQueryObservable {
 
       decoder: ZooAnimalsContractQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
@@ -18,10 +18,14 @@ abstract class $ZooAnimalsContractQuery extends StatefulWidget {
   String operation$Name() => 'ZooAnimalsContractQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   const $ZooAnimalsContractQuery({
     super.key,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -68,6 +72,8 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
     _sub =
         ZooAnimalsContractQueryObservable(
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.shalom.dart
@@ -235,9 +235,13 @@ final class ShelterSubscriptionData implements shalom_core.OperationInterface {
 
 final class ShelterSubscriptionObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   const ShelterSubscriptionObservable({
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'ShelterSubscription';
@@ -250,6 +254,8 @@ final class ShelterSubscriptionObservable {
 
       decoder: ShelterSubscriptionData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
@@ -14,8 +14,15 @@ abstract class $ShelterSubscription extends StatefulWidget {
   String operation$Name() => 'ShelterSubscription';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
-  const $ShelterSubscription({super.key, this.executionPolicy = .cacheFirst});
+  const $ShelterSubscription({
+    super.key,
+    this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
+  });
 
   Widget buildLoading(BuildContext context);
   Widget buildError(BuildContext context, Object error);
@@ -58,7 +65,11 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
     _sub?.cancel();
     final client = ShalomScope.of(context);
     _sub =
-        ShelterSubscriptionObservable(executionPolicy: widget.executionPolicy)
+        ShelterSubscriptionObservable(
+              executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
+            )
             .observe(client)
             .listen(
               (response) {

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.shalom.dart
@@ -235,9 +235,13 @@ final class StreetSubscriptionData implements shalom_core.OperationInterface {
 
 final class StreetSubscriptionObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   const StreetSubscriptionObservable({
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'StreetSubscription';
@@ -250,6 +254,8 @@ final class StreetSubscriptionObservable {
 
       decoder: StreetSubscriptionData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
@@ -14,8 +14,15 @@ abstract class $StreetSubscription extends StatefulWidget {
   String operation$Name() => 'StreetSubscription';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
-  const $StreetSubscription({super.key, this.executionPolicy = .cacheFirst});
+  const $StreetSubscription({
+    super.key,
+    this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
+  });
 
   Widget buildLoading(BuildContext context);
   Widget buildError(BuildContext context, Object error);
@@ -56,25 +63,30 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
   void _subscribe() {
     _sub?.cancel();
     final client = ShalomScope.of(context);
-    _sub = StreetSubscriptionObservable(executionPolicy: widget.executionPolicy)
-        .observe(client)
-        .listen(
-          (response) {
-            setState(() {
-              switch (response) {
-                case shalom_core.GraphQLData(data: final data):
-                  _data = data;
-                  _error = null;
-                case shalom_core.GraphQLError() ||
-                    shalom_core.LinkExceptionResponse():
-                  _error = response;
-              }
-            });
-          },
-          onDone: () {
-            if (mounted) _subscribe();
-          },
-        );
+    _sub =
+        StreetSubscriptionObservable(
+              executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
+            )
+            .observe(client)
+            .listen(
+              (response) {
+                setState(() {
+                  switch (response) {
+                    case shalom_core.GraphQLData(data: final data):
+                      _data = data;
+                      _error = null;
+                    case shalom_core.GraphQLError() ||
+                        shalom_core.LinkExceptionResponse():
+                      _error = response;
+                  }
+                });
+              },
+              onDone: () {
+                if (mounted) _subscribe();
+              },
+            );
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.shalom.dart
@@ -217,6 +217,8 @@ final class AnimalQueryData implements shalom_core.OperationInterface {
 
 final class AnimalQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final AnimalQueryVariables variables;
 
@@ -224,6 +226,8 @@ final class AnimalQueryObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'AnimalQuery';
@@ -238,6 +242,8 @@ final class AnimalQueryObservable {
 
       decoder: AnimalQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
@@ -14,12 +14,16 @@ abstract class $AnimalQuery extends StatefulWidget {
   String operation$Name() => 'AnimalQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final AnimalQueryVariables variables;
   const $AnimalQuery({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -67,6 +71,8 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.shalom.dart
@@ -257,6 +257,8 @@ final class AnimalWithOwnerQueryData implements shalom_core.OperationInterface {
 
 final class AnimalWithOwnerQueryObservable {
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final AnimalWithOwnerQueryVariables variables;
 
@@ -264,6 +266,8 @@ final class AnimalWithOwnerQueryObservable {
     required this.variables,
 
     this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+    this.retryDelay = const shalom_core.RetryDelay.inherit(),
+    this.autoRefetch,
   });
 
   String operation$Name() => 'AnimalWithOwnerQuery';
@@ -278,6 +282,8 @@ final class AnimalWithOwnerQueryObservable {
 
       decoder: AnimalWithOwnerQueryData.fromCache,
       executionPolicy: executionPolicy,
+      retryDelay: retryDelay,
+      autoRefetch: autoRefetch,
     );
   }
 }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
@@ -14,12 +14,16 @@ abstract class $AnimalWithOwnerQuery extends StatefulWidget {
   String operation$Name() => 'AnimalWithOwnerQuery';
 
   final shalom_core.ExecutionPolicyInput executionPolicy;
+  final shalom_core.RetryDelay retryDelay;
+  final Duration? autoRefetch;
 
   final AnimalWithOwnerQueryVariables variables;
   const $AnimalWithOwnerQuery({
     super.key,
     required this.variables,
     this.executionPolicy = .cacheFirst,
+    this.retryDelay = const .inherit(),
+    this.autoRefetch,
   });
 
   Widget buildLoading(BuildContext context);
@@ -68,6 +72,8 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
               variables: widget.variables,
 
               executionPolicy: widget.executionPolicy,
+              retryDelay: widget.retryDelay,
+              autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_dart_codegen/templates/operation.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation.dart.jinja
@@ -147,6 +147,8 @@ final class {{ operation_name }}Data implements shalom_core.OperationInterface {
 
 final class {{ operation_name }}Observable {
     final shalom_core.ExecutionPolicyInput executionPolicy;
+    final shalom_core.RetryDelay retryDelay;
+    final Duration? autoRefetch;
     {% if op_variables_exist %}
     final {{ operation_name }}Variables variables;
     {% endif %}
@@ -156,6 +158,8 @@ final class {{ operation_name }}Observable {
         required this.variables,
         {% endif %}
         this.executionPolicy = shalom_core.ExecutionPolicyInput.cacheFirst,
+        this.retryDelay = const shalom_core.RetryDelay.inherit(),
+        this.autoRefetch,
     });
 
     String operation$Name() => '{{ operation_name }}';
@@ -168,6 +172,8 @@ final class {{ operation_name }}Observable {
             {% endif %}
             decoder: {{ operation_name }}Data.fromCache,
             executionPolicy: executionPolicy,
+            retryDelay: retryDelay,
+            autoRefetch: autoRefetch,
         );
     }
 }

--- a/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
@@ -23,11 +23,13 @@ abstract class ${{ operation_name }} extends StatefulWidget {
     String operation$Name() => '{{ operation_name }}';
 
     final shalom_core.ExecutionPolicyInput executionPolicy;
+    final shalom_core.RetryDelay retryDelay;
+    final Duration? autoRefetch;
     {% if op_variables_exist %}
         final {{ operation_name }}Variables variables;
-        const ${{ operation_name }}({super.key, required this.variables, this.executionPolicy = .cacheFirst});
+        const ${{ operation_name }}({super.key, required this.variables, this.executionPolicy = .cacheFirst, this.retryDelay = const .inherit(), this.autoRefetch});
     {% else %}
-        const ${{ operation_name }}({super.key, this.executionPolicy = .cacheFirst});
+        const ${{ operation_name }}({super.key, this.executionPolicy = .cacheFirst, this.retryDelay = const .inherit(), this.autoRefetch});
     {% endif %}
 
     Widget buildLoading(BuildContext context);
@@ -71,6 +73,8 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
                 variables: widget.variables,
                 {% endif %}
                 executionPolicy: widget.executionPolicy,
+                retryDelay: widget.retryDelay,
+                autoRefetch: widget.autoRefetch,
             )
             .observe(client)
             .listen(

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -501,6 +501,14 @@ impl ShalomRuntime {
                 let Some(wait) = wait else {
                     return;
                 };
+                // `cancel.notified()` only wakes a task that's already awaiting
+                // it — if `unsubscribe` fired between the inner loop ending and
+                // here, that notification is lost and a freshly created
+                // `notified()` future below would never resolve. Check first so
+                // an already-cancelled subscription doesn't sleep needlessly.
+                if !runtime.subscription_exists(&sub_id) {
+                    return;
+                }
                 tokio::select! {
                     biased;
                     _ = cancel.notified() => return,

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use parking_lot::Mutex;
 use serde_json::{Map, Value};
 use tokio::sync::{Notify, mpsc};
-use tokio_stream::{Stream, StreamExt};
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::{Stream, StreamExt};
 
 use shalom_core::context::SharedShalomGlobalContext;
 use shalom_core::entrypoint::{parse_document, parse_schema, register_fragments_from_document};
@@ -411,11 +411,8 @@ impl ShalomRuntime {
         link: Arc<dyn GraphQLLink>,
         retry_delay: Option<Duration>,
     ) -> SubscriptionId {
-        let sub_id = self.create_operation_subscription(
-            op_ctx.clone(),
-            variables.clone(),
-            execution_policy,
-        );
+        let sub_id =
+            self.create_operation_subscription(op_ctx.clone(), variables.clone(), execution_policy);
 
         // Cancellation signal: fired by `unsubscribe` so this task can abort an
         // in-flight `stream.next()` (or a pending retry sleep) immediately,
@@ -1237,9 +1234,7 @@ fn subscription_refs_for_result(result: &crate::read::ReadResult) -> HashSet<Str
     refs
 }
 
-fn to_link_op_type(
-    op_type: shalom_core::operation::types::OperationType,
-) -> LinkOperationType {
+fn to_link_op_type(op_type: shalom_core::operation::types::OperationType) -> LinkOperationType {
     match op_type {
         shalom_core::operation::types::OperationType::Query => LinkOperationType::Query,
         shalom_core::operation::types::OperationType::Mutation => LinkOperationType::Mutation,

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use parking_lot::Mutex;
 use serde_json::{Map, Value};
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tokio_stream::{Stream, StreamExt};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -182,6 +182,10 @@ struct SubscriptionState {
     keys: HashSet<String>,
     sender: mpsc::UnboundedSender<Result<RuntimeResponse, SubscriptionError>>,
     receiver: Option<mpsc::UnboundedReceiver<Result<RuntimeResponse, SubscriptionError>>>,
+    /// Fired when this subscription is unsubscribed, so any in-flight network
+    /// request driving it (see [`ShalomRuntime::execute_operation`]) can abort
+    /// immediately instead of waiting on the next stream item.
+    cancel: Arc<Notify>,
 }
 
 #[derive(Clone)]
@@ -413,6 +417,14 @@ impl ShalomRuntime {
             execution_policy,
         );
 
+        // Cancellation signal: fired by `unsubscribe` so this task can abort an
+        // in-flight `stream.next()` (or a pending retry sleep) immediately,
+        // rather than only noticing at the next stream item / after the delay.
+        let Some(cancel) = self.subscription_cancel_signal(&sub_id) else {
+            // Already unsubscribed before the task even got a chance to run.
+            return sub_id;
+        };
+
         let runtime = self.clone();
         tokio::spawn(async move {
             let request = Request {
@@ -427,7 +439,16 @@ impl ShalomRuntime {
                 let mut stream = link.execute(request.clone());
                 let mut transport_failed = false;
 
-                while let Some(response) = stream.next().await {
+                loop {
+                    let response = tokio::select! {
+                        biased;
+                        _ = cancel.notified() => return,
+                        item = stream.next() => match item {
+                            Some(response) => response,
+                            None => break,
+                        },
+                    };
+
                     match response {
                         GraphQLResponse::Data { data, .. } => {
                             if let Err(e) =
@@ -473,7 +494,11 @@ impl ShalomRuntime {
                 let Some(delay) = retry_delay else {
                     return;
                 };
-                tokio::time::sleep(delay).await;
+                tokio::select! {
+                    biased;
+                    _ = cancel.notified() => return,
+                    _ = tokio::time::sleep(delay) => {}
+                }
                 if !runtime.subscription_exists(&sub_id) {
                     return;
                 }
@@ -745,12 +770,16 @@ impl ShalomRuntime {
     }
 
     pub fn unsubscribe(&self, id: &SubscriptionId) {
-        let keys = {
+        let removed = {
             let mut manager = self.subscriptions.lock();
-            manager.subscriptions.remove(id).map(|state| state.keys)
+            manager.subscriptions.remove(id)
         };
-        if let Some(keys) = keys {
-            self.subscription_tracker.lock().unsubscribe(keys);
+        if let Some(state) = removed {
+            // Wake any in-flight network request driving this subscription
+            // (see `execute_operation`) so it aborts immediately instead of
+            // waiting on the next stream item.
+            state.cancel.notify_waiters();
+            self.subscription_tracker.lock().unsubscribe(state.keys);
         }
     }
 
@@ -979,11 +1008,23 @@ impl ShalomRuntime {
                 keys: refs,
                 sender,
                 receiver: Some(receiver),
+                cancel: Arc::new(Notify::new()),
             },
         );
         drop(manager);
         self.subscription_tracker.lock().subscribe(keys);
         id
+    }
+
+    /// The cancellation signal for a subscription, fired when it's unsubscribed.
+    /// Used by [`Self::execute_operation`] to abort an in-flight network
+    /// request promptly instead of waiting on the next stream item.
+    fn subscription_cancel_signal(&self, id: &SubscriptionId) -> Option<Arc<Notify>> {
+        self.subscriptions
+            .lock()
+            .subscriptions
+            .get(id)
+            .map(|state| state.cancel.clone())
     }
 
     fn notify_subscribers(&self, changed: &HashSet<String>) -> anyhow::Result<()> {

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use parking_lot::Mutex;
 use serde_json::{Map, Value};
 use tokio::sync::mpsc;
-use tokio_stream::Stream;
+use tokio_stream::{Stream, StreamExt};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use shalom_core::context::SharedShalomGlobalContext;
@@ -22,6 +22,9 @@ use crate::execution::ExecutionEngine;
 use crate::gc::{SubscriptionTracker, collect_garbage};
 use crate::normalization::NormalizationResult;
 use crate::read::CacheReader;
+use crate::sansio_protocols::{
+    GraphQLLink, GraphQLResponse, OperationType as LinkOperationType, Request,
+};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -36,6 +39,10 @@ pub struct RuntimeConfig {
     /// last real subscriber unsubscribes, before it becomes eligible for GC.
     /// Zero means no grace period — the previous behaviour.
     pub retention_grace: Duration,
+    /// Default delay before retrying an operation (query/mutation/subscription)
+    /// after a transport error, when the operation didn't override it.
+    /// `None` means auto-retry is off by default.
+    pub default_retry_delay: Option<Duration>,
 }
 
 impl Default for RuntimeConfig {
@@ -43,6 +50,7 @@ impl Default for RuntimeConfig {
         Self {
             gc_interval: Duration::from_secs(2),
             retention_grace: Duration::ZERO,
+            default_retry_delay: None,
         }
     }
 }
@@ -214,6 +222,9 @@ pub struct ShalomRuntime {
     optimistic_writes: Arc<Mutex<HashMap<OptimisticWriteId, OptimisticWrite>>>,
     /// Monotonic counter for generating `OptimisticWriteId`s.
     next_optimistic_id: Arc<AtomicU64>,
+    /// Default retry delay for operations that don't override it. See
+    /// [`RuntimeConfig::default_retry_delay`].
+    default_retry_delay: Option<Duration>,
 }
 
 impl Drop for ShalomRuntime {
@@ -291,6 +302,7 @@ impl ShalomRuntime {
             ))),
             operation_vars: Arc::new(Mutex::new(HashMap::new())),
             shutdown: Arc::new(AtomicBool::new(false)),
+            default_retry_delay: config.default_retry_delay,
             optimistic_writes: Arc::new(Mutex::new(HashMap::new())),
             next_optimistic_id: Arc::new(AtomicU64::new(0)),
         }
@@ -375,6 +387,101 @@ impl ShalomRuntime {
     // -----------------------------------------------------------------------
     // Subscriptions — widget API
     // -----------------------------------------------------------------------
+
+    /// Create a cache subscription for a pre-registered operation, trigger the
+    /// network request through `link`, and normalise each response as it
+    /// arrives.
+    ///
+    /// If the link reports a [`crate::sansio_protocols::GraphQLResponse::TransportError`],
+    /// the error is pushed to the subscription (so the caller sees it
+    /// immediately) and, if `retry_delay` is set, the whole request is
+    /// re-issued (a fresh `link.execute` call) after the delay — as long as
+    /// the subscription hasn't been unsubscribed in the meantime. A
+    /// GraphQL-level error or a normalization failure is terminal: retrying
+    /// the same request/data wouldn't change the outcome.
+    pub fn execute_operation(
+        &self,
+        op_ctx: SharedOpCtx,
+        variables: Option<Map<String, Value>>,
+        execution_policy: ExecutionPolicy,
+        link: Arc<dyn GraphQLLink>,
+        retry_delay: Option<Duration>,
+    ) -> SubscriptionId {
+        let sub_id = self.create_operation_subscription(
+            op_ctx.clone(),
+            variables.clone(),
+            execution_policy,
+        );
+
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            let request = Request {
+                query: op_ctx.query.clone(),
+                variables: variables.clone().unwrap_or_default(),
+                operation_name: op_ctx.get_operation_name().to_string(),
+                operation_type: to_link_op_type(op_ctx.op_type()),
+                headers: None,
+            };
+
+            loop {
+                let mut stream = link.execute(request.clone());
+                let mut transport_failed = false;
+
+                while let Some(response) = stream.next().await {
+                    match response {
+                        GraphQLResponse::Data { data, .. } => {
+                            if let Err(e) =
+                                runtime.normalize(&op_ctx, Value::Object(data), variables.as_ref())
+                            {
+                                runtime.push_subscription_error(
+                                    sub_id,
+                                    SubscriptionError::Transport {
+                                        message: e.to_string(),
+                                        code: "NORMALIZATION_ERROR".into(),
+                                        details: None,
+                                    },
+                                );
+                                return;
+                            }
+                        }
+                        GraphQLResponse::Error { errors, extensions } => {
+                            runtime.push_subscription_error(
+                                sub_id,
+                                SubscriptionError::GraphQL { errors, extensions },
+                            );
+                            return;
+                        }
+                        GraphQLResponse::TransportError(err) => {
+                            runtime.push_subscription_error(
+                                sub_id,
+                                SubscriptionError::Transport {
+                                    message: err.message,
+                                    code: err.code,
+                                    details: err.details,
+                                },
+                            );
+                            transport_failed = true;
+                            break;
+                        }
+                    }
+                }
+
+                if !transport_failed {
+                    // Stream ended cleanly (link signalled completion) — nothing to retry.
+                    return;
+                }
+                let Some(delay) = retry_delay else {
+                    return;
+                };
+                tokio::time::sleep(delay).await;
+                if !runtime.subscription_exists(&sub_id) {
+                    return;
+                }
+            }
+        });
+
+        sub_id
+    }
 
     /// Create a cache subscription for a pre-registered operation and return
     /// its ID. The caller (FRB layer) is responsible for also triggering the
@@ -626,6 +733,16 @@ impl ShalomRuntime {
     // -----------------------------------------------------------------------
     // Subscription lifecycle
     // -----------------------------------------------------------------------
+
+    /// The default retry delay configured via [`RuntimeConfig::default_retry_delay`].
+    pub fn default_retry_delay(&self) -> Option<Duration> {
+        self.default_retry_delay
+    }
+
+    /// Whether a subscription is still active (i.e. hasn't been [`unsubscribe`]d).
+    pub fn subscription_exists(&self, id: &SubscriptionId) -> bool {
+        self.subscriptions.lock().subscriptions.contains_key(id)
+    }
 
     pub fn unsubscribe(&self, id: &SubscriptionId) {
         let keys = {
@@ -1077,4 +1194,16 @@ fn subscription_refs_for_result(result: &crate::read::ReadResult) -> HashSet<Str
     let mut refs = result.used_refs.clone();
     refs.extend(result.missing_refs.iter().cloned());
     refs
+}
+
+fn to_link_op_type(
+    op_type: shalom_core::operation::types::OperationType,
+) -> LinkOperationType {
+    match op_type {
+        shalom_core::operation::types::OperationType::Query => LinkOperationType::Query,
+        shalom_core::operation::types::OperationType::Mutation => LinkOperationType::Mutation,
+        shalom_core::operation::types::OperationType::Subscription => {
+            LinkOperationType::Subscription
+        }
+    }
 }

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -403,6 +403,12 @@ impl ShalomRuntime {
     /// the subscription hasn't been unsubscribed in the meantime. A
     /// GraphQL-level error or a normalization failure is terminal: retrying
     /// the same request/data wouldn't change the outcome.
+    ///
+    /// If the link's stream ends cleanly (no transport error — typically a
+    /// one-shot query/mutation over HTTP) and `refetch_interval` is set, the
+    /// request is re-issued after the interval, as long as the subscription
+    /// is still observed. This is a plain polling refetch, independent of any
+    /// error handling; it's only meaningful for queries.
     pub fn execute_operation(
         &self,
         op_ctx: SharedOpCtx,
@@ -410,6 +416,7 @@ impl ShalomRuntime {
         execution_policy: ExecutionPolicy,
         link: Arc<dyn GraphQLLink>,
         retry_delay: Option<Duration>,
+        refetch_interval: Option<Duration>,
     ) -> SubscriptionId {
         let sub_id =
             self.create_operation_subscription(op_ctx.clone(), variables.clone(), execution_policy);
@@ -484,17 +491,20 @@ impl ShalomRuntime {
                     }
                 }
 
-                if !transport_failed {
-                    // Stream ended cleanly (link signalled completion) — nothing to retry.
-                    return;
-                }
-                let Some(delay) = retry_delay else {
+                let wait = if transport_failed {
+                    retry_delay
+                } else {
+                    // Stream ended cleanly (link signalled completion) — only
+                    // re-issue if a polling refetch interval was requested.
+                    refetch_interval
+                };
+                let Some(wait) = wait else {
                     return;
                 };
                 tokio::select! {
                     biased;
                     _ = cancel.notified() => return,
-                    _ = tokio::time::sleep(delay) => {}
+                    _ = tokio::time::sleep(wait) => {}
                 }
                 if !runtime.subscription_exists(&sub_id) {
                     return;

--- a/rust/shalom_runtime/tests/retry.rs
+++ b/rust/shalom_runtime/tests/retry.rs
@@ -36,6 +36,7 @@ async fn transport_error_retries_and_recovers() {
         ExecutionPolicy::NetworkFirst,
         link.clone() as Arc<dyn GraphQLLink>,
         Some(Duration::from_millis(20)),
+        None,
     );
     let mut responses = runtime
         .subscription_stream(&sub_id)
@@ -80,6 +81,118 @@ async fn transport_error_retries_and_recovers() {
     assert_eq!(second.data.get("value"), Some(&json!(42)));
 }
 
+/// A `refetch_interval` re-issues a query on a timer once its stream ends
+/// cleanly (no transport error) — a plain polling refetch.
+#[tokio::test]
+async fn refetch_interval_reissues_after_clean_completion() {
+    let link = Arc::new(HostLink::new());
+    let mut outgoing = link.take_request_stream().expect("request stream missing");
+    let runtime =
+        ShalomRuntime::init(SCHEMA, Vec::new(), RuntimeConfig::default()).expect("runtime init");
+    let op_ctx = runtime
+        .register_operation("query TestOp @observe { value }")
+        .expect("register operation");
+
+    let sub_id = runtime.execute_operation(
+        op_ctx,
+        None,
+        ExecutionPolicy::NetworkFirst,
+        link.clone() as Arc<dyn GraphQLLink>,
+        None,
+        Some(Duration::from_millis(20)),
+    );
+    let mut responses = runtime
+        .subscription_stream(&sub_id)
+        .expect("subscription stream");
+
+    let first_envelope = outgoing.next().await.expect("first request missing");
+    link.send_response(
+        first_envelope.id,
+        GraphQLResponse::Data {
+            data: json!({ "value": 1 }).as_object().unwrap().clone(),
+            errors: None,
+            extensions: None,
+        },
+    )
+    .expect("send data");
+    // Signal the stream ended cleanly (e.g. an HTTP link closing after one response).
+    link.complete(first_envelope.id);
+
+    let first = responses
+        .next()
+        .await
+        .expect("missing response")
+        .expect("first response should be ok");
+    assert_eq!(first.data.get("value"), Some(&json!(1)));
+
+    // After the refetch interval, the query is re-issued as a fresh request.
+    let refetch_envelope = outgoing.next().await.expect("refetch request missing");
+    assert_ne!(refetch_envelope.id, first_envelope.id);
+    link.send_response(
+        refetch_envelope.id,
+        GraphQLResponse::Data {
+            data: json!({ "value": 2 }).as_object().unwrap().clone(),
+            errors: None,
+            extensions: None,
+        },
+    )
+    .expect("send data");
+    link.complete(refetch_envelope.id);
+
+    let second = responses
+        .next()
+        .await
+        .expect("missing response")
+        .expect("refetch response should be ok");
+    assert_eq!(second.data.get("value"), Some(&json!(2)));
+}
+
+/// Without a `refetch_interval`, a query's stream ending cleanly is terminal:
+/// it's not re-issued.
+#[tokio::test]
+async fn clean_completion_without_refetch_interval_does_not_refetch() {
+    let link = Arc::new(HostLink::new());
+    let mut outgoing = link.take_request_stream().expect("request stream missing");
+    let runtime =
+        ShalomRuntime::init(SCHEMA, Vec::new(), RuntimeConfig::default()).expect("runtime init");
+    let op_ctx = runtime
+        .register_operation("query TestOp @observe { value }")
+        .expect("register operation");
+
+    let sub_id = runtime.execute_operation(
+        op_ctx,
+        None,
+        ExecutionPolicy::NetworkFirst,
+        link.clone() as Arc<dyn GraphQLLink>,
+        None,
+        None,
+    );
+    let mut responses = runtime
+        .subscription_stream(&sub_id)
+        .expect("subscription stream");
+
+    let envelope = outgoing.next().await.expect("request missing");
+    link.send_response(
+        envelope.id,
+        GraphQLResponse::Data {
+            data: json!({ "value": 1 }).as_object().unwrap().clone(),
+            errors: None,
+            extensions: None,
+        },
+    )
+    .expect("send data");
+    link.complete(envelope.id);
+
+    let first = responses.next().await.expect("missing response");
+    assert!(first.is_ok());
+
+    let no_refetch = tokio::time::timeout(Duration::from_millis(100), outgoing.next()).await;
+    assert!(
+        no_refetch.is_err(),
+        "expected no refetch request to be sent"
+    );
+}
+
 /// If the operation didn't opt into auto-retry, a transport error is terminal:
 /// it's pushed once and the operation is not re-issued.
 #[tokio::test]
@@ -97,6 +210,7 @@ async fn transport_error_without_retry_delay_does_not_retry() {
         None,
         ExecutionPolicy::NetworkFirst,
         link.clone() as Arc<dyn GraphQLLink>,
+        None,
         None,
     );
     let mut responses = runtime
@@ -140,6 +254,7 @@ async fn unsubscribing_before_retry_cancels_it() {
         ExecutionPolicy::NetworkFirst,
         link.clone() as Arc<dyn GraphQLLink>,
         Some(Duration::from_millis(30)),
+        None,
     );
     let mut responses = runtime
         .subscription_stream(&sub_id)
@@ -232,6 +347,7 @@ async fn unsubscribing_aborts_in_flight_stream_promptly() {
         None,
         ExecutionPolicy::NetworkFirst,
         link.clone() as Arc<dyn GraphQLLink>,
+        None,
         None,
     );
 

--- a/rust/shalom_runtime/tests/retry.rs
+++ b/rust/shalom_runtime/tests/retry.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use tokio_stream::StreamExt;
+
+use shalom_runtime::sansio_protocols::host::HostLink;
+use shalom_runtime::sansio_protocols::{GraphQLLink, GraphQLResponse, TransportError};
+use shalom_runtime::{ExecutionPolicy, RuntimeConfig, ShalomRuntime};
+
+const SCHEMA: &str = r#"
+    type Query { value: Int }
+"#;
+
+/// A transport error is pushed to the subscription immediately, and — since a
+/// retry delay is configured — the whole operation is re-issued afterwards,
+/// resuming the subscription once the retry succeeds.
+#[tokio::test]
+async fn transport_error_retries_and_recovers() {
+    let link = Arc::new(HostLink::new());
+    let mut outgoing = link.take_request_stream().expect("request stream missing");
+    let runtime =
+        ShalomRuntime::init(SCHEMA, Vec::new(), RuntimeConfig::default()).expect("runtime init");
+    let op_ctx = runtime
+        .register_operation("query TestOp @observe { value }")
+        .expect("register operation");
+
+    let sub_id = runtime.execute_operation(
+        op_ctx,
+        None,
+        ExecutionPolicy::NetworkFirst,
+        link.clone() as Arc<dyn GraphQLLink>,
+        Some(Duration::from_millis(20)),
+    );
+    let mut responses = runtime
+        .subscription_stream(&sub_id)
+        .expect("subscription stream");
+
+    let first_envelope = outgoing.next().await.expect("first request missing");
+    assert_eq!(first_envelope.request.operation_name, "TestOp");
+    link.send_response(
+        first_envelope.id,
+        GraphQLResponse::TransportError(TransportError {
+            message: "connection lost".into(),
+            code: "NETWORK_ERROR".into(),
+            details: None,
+        }),
+    )
+    .expect("send transport error");
+
+    // The transport error is surfaced immediately.
+    let first = responses.next().await.expect("missing response");
+    assert!(first.is_err());
+
+    // After the retry delay, the same operation is re-issued as a fresh request.
+    let retry_envelope = outgoing.next().await.expect("retry request missing");
+    assert_eq!(retry_envelope.request.operation_name, "TestOp");
+    assert_ne!(retry_envelope.id, first_envelope.id);
+
+    link.send_response(
+        retry_envelope.id,
+        GraphQLResponse::Data {
+            data: json!({ "value": 42 }).as_object().unwrap().clone(),
+            errors: None,
+            extensions: None,
+        },
+    )
+    .expect("send data");
+
+    let second = responses
+        .next()
+        .await
+        .expect("missing response")
+        .expect("retry response should be ok");
+    assert_eq!(second.data.get("value"), Some(&json!(42)));
+}
+
+/// If the operation didn't opt into auto-retry, a transport error is terminal:
+/// it's pushed once and the operation is not re-issued.
+#[tokio::test]
+async fn transport_error_without_retry_delay_does_not_retry() {
+    let link = Arc::new(HostLink::new());
+    let mut outgoing = link.take_request_stream().expect("request stream missing");
+    let runtime =
+        ShalomRuntime::init(SCHEMA, Vec::new(), RuntimeConfig::default()).expect("runtime init");
+    let op_ctx = runtime
+        .register_operation("query TestOp @observe { value }")
+        .expect("register operation");
+
+    let sub_id = runtime.execute_operation(
+        op_ctx,
+        None,
+        ExecutionPolicy::NetworkFirst,
+        link.clone() as Arc<dyn GraphQLLink>,
+        None,
+    );
+    let mut responses = runtime
+        .subscription_stream(&sub_id)
+        .expect("subscription stream");
+
+    let envelope = outgoing.next().await.expect("request missing");
+    link.send_response(
+        envelope.id,
+        GraphQLResponse::TransportError(TransportError {
+            message: "connection lost".into(),
+            code: "NETWORK_ERROR".into(),
+            details: None,
+        }),
+    )
+    .expect("send transport error");
+
+    let first = responses.next().await.expect("missing response");
+    assert!(first.is_err());
+
+    // No retry: no second request ever arrives.
+    let no_retry = tokio::time::timeout(Duration::from_millis(100), outgoing.next()).await;
+    assert!(no_retry.is_err(), "expected no retry request to be sent");
+}
+
+/// Unsubscribing before the retry delay elapses cancels the pending retry —
+/// the operation is not re-issued after cancellation.
+#[tokio::test]
+async fn unsubscribing_before_retry_cancels_it() {
+    let link = Arc::new(HostLink::new());
+    let mut outgoing = link.take_request_stream().expect("request stream missing");
+    let runtime =
+        ShalomRuntime::init(SCHEMA, Vec::new(), RuntimeConfig::default()).expect("runtime init");
+    let op_ctx = runtime
+        .register_operation("query TestOp @observe { value }")
+        .expect("register operation");
+
+    let sub_id = runtime.execute_operation(
+        op_ctx,
+        None,
+        ExecutionPolicy::NetworkFirst,
+        link.clone() as Arc<dyn GraphQLLink>,
+        Some(Duration::from_millis(30)),
+    );
+    let mut responses = runtime
+        .subscription_stream(&sub_id)
+        .expect("subscription stream");
+
+    let envelope = outgoing.next().await.expect("request missing");
+    link.send_response(
+        envelope.id,
+        GraphQLResponse::TransportError(TransportError {
+            message: "connection lost".into(),
+            code: "NETWORK_ERROR".into(),
+            details: None,
+        }),
+    )
+    .expect("send transport error");
+
+    let first = responses.next().await.expect("missing response");
+    assert!(first.is_err());
+
+    // Cancel before the retry delay (30ms) elapses.
+    runtime.unsubscribe(&sub_id);
+
+    let no_retry = tokio::time::timeout(Duration::from_millis(100), outgoing.next()).await;
+    assert!(
+        no_retry.is_err(),
+        "expected no retry request after cancellation"
+    );
+}

--- a/rust/shalom_runtime/tests/retry.rs
+++ b/rust/shalom_runtime/tests/retry.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use serde_json::json;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_stream::StreamExt;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use shalom_runtime::sansio_protocols::host::HostLink;
 use shalom_runtime::sansio_protocols::{

--- a/rust/shalom_runtime/tests/retry.rs
+++ b/rust/shalom_runtime/tests/retry.rs
@@ -1,11 +1,16 @@
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use serde_json::json;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_stream::StreamExt;
 
 use shalom_runtime::sansio_protocols::host::HostLink;
-use shalom_runtime::sansio_protocols::{GraphQLLink, GraphQLResponse, TransportError};
+use shalom_runtime::sansio_protocols::{
+    GraphQLLink, GraphQLResponse, LinkStream, Request, TransportError,
+};
 use shalom_runtime::{ExecutionPolicy, RuntimeConfig, ShalomRuntime};
 
 const SCHEMA: &str = r#"
@@ -161,5 +166,89 @@ async fn unsubscribing_before_retry_cancels_it() {
     assert!(
         no_retry.is_err(),
         "expected no retry request after cancellation"
+    );
+}
+
+/// A [`GraphQLLink`] whose stream never completes and never yields another
+/// item (simulating a live, still-open network subscription), instrumented to
+/// report when the stream itself is dropped.
+struct PendingForeverLink {
+    dropped: Arc<AtomicBool>,
+    /// Keeps each request's channel sender alive so its receiver stream never
+    /// closes on its own — the only way it ends is by being dropped.
+    senders: Mutex<Vec<mpsc::UnboundedSender<GraphQLResponse>>>,
+}
+
+struct DropFlagStream {
+    inner: UnboundedReceiverStream<GraphQLResponse>,
+    dropped: Arc<AtomicBool>,
+}
+
+impl tokio_stream::Stream for DropFlagStream {
+    type Item = GraphQLResponse;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::pin::Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl Drop for DropFlagStream {
+    fn drop(&mut self) {
+        self.dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+impl GraphQLLink for PendingForeverLink {
+    fn execute(&self, _request: Request) -> LinkStream {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.senders.lock().unwrap().push(tx);
+        Box::pin(DropFlagStream {
+            inner: UnboundedReceiverStream::new(rx),
+            dropped: self.dropped.clone(),
+        })
+    }
+}
+
+/// A live subscription's in-flight stream must be aborted promptly on
+/// `unsubscribe` — not left polling forever until the link happens to produce
+/// another item (which, for an open GraphQL subscription, may be never).
+#[tokio::test]
+async fn unsubscribing_aborts_in_flight_stream_promptly() {
+    let dropped = Arc::new(AtomicBool::new(false));
+    let link = Arc::new(PendingForeverLink {
+        dropped: dropped.clone(),
+        senders: Mutex::new(Vec::new()),
+    });
+    let runtime =
+        ShalomRuntime::init(SCHEMA, Vec::new(), RuntimeConfig::default()).expect("runtime init");
+    let op_ctx = runtime
+        .register_operation("query TestOp @observe { value }")
+        .expect("register operation");
+
+    let sub_id = runtime.execute_operation(
+        op_ctx,
+        None,
+        ExecutionPolicy::NetworkFirst,
+        link.clone() as Arc<dyn GraphQLLink>,
+        None,
+    );
+
+    // Give the spawned task a chance to call `link.execute` and start polling.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "stream should still be open before unsubscribe"
+    );
+
+    runtime.unsubscribe(&sub_id);
+
+    // The in-flight stream should be dropped promptly, not held open
+    // indefinitely waiting for a network item that may never come.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        dropped.load(Ordering::SeqCst),
+        "stream should be aborted promptly after unsubscribe"
     );
 }


### PR DESCRIPTION
## Summary by Sourcery

Add configurable automatic retry and refetch behavior for GraphQL operations after transport errors, with runtime-level defaults and per-request overrides across Rust and Dart layers.

New Features:
- Introduce runtime configuration for a default retry delay applied to operations after transport errors.
- Add per-request retry delay controls, including inherit, disabled, and explicit millisecond delays, exposed through the Dart client API.
- Provide a unified runtime method to execute operations that handles streaming responses, normalization, and automatic retry logic.

Enhancements:
- Refactor request execution from the FRB layer into the core Rust runtime, including a helper for converting operation types to link operation types.

Tests:
- Add integration tests verifying retry-on-transport-error behavior, no-retry scenarios, and cancellation of pending retries upon unsubscribe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry delays for runtime requests, with options to inherit defaults, disable retries, or set a custom delay.
  * Added a runtime-level default retry delay setting for more consistent behavior across requests.

* **Bug Fixes**
  * Mutations now avoid automatic retries unless explicitly enabled.
  * Transport errors are surfaced immediately, while retry behavior is now handled more predictably, including cancellation when subscriptions end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->