### PR TITLE
Fix stale operation widgets (constant loading)

### DIFF
--- a/dart/shalom/lib/src/runtime_client.dart
+++ b/dart/shalom/lib/src/runtime_client.dart
@@ -227,52 +227,20 @@ class ShalomRuntimeClient {
     Duration? autoRefetch,
   }) {
     final variablesJson = variables == null ? null : jsonEncode(variables);
-    BigInt? subId;
-    var cancelled = false;
-    final controller = StreamController<GraphQLResponse<T>>();
-
-    controller.onListen = () {
-      Future.microtask(() async {
-        try {
-          subId = await rs_runtime.request(
-            handle: _handle,
-            name: name,
-            variablesJson: variablesJson,
-            executionPolicy: executionPolicy,
-            retryDelay: retryDelay._toInput(),
-            refetchIntervalMs: autoRefetch != null
-                ? BigInt.from(autoRefetch.inMilliseconds)
-                : null,
-          );
-          if (cancelled || controller.isClosed) {
-            if (subId != null) {
-              await rs_runtime.unsubscribe(
-                handle: _handle,
-                subscriptionId: subId!,
-              );
-            }
-            return;
-          }
-          _bindSubscriptionStream(
-            subId: subId!,
-            controller: controller,
-            decoder: decoder,
-            debugName: name,
-          );
-        } catch (e, st) {
-          if (!cancelled && !controller.isClosed) controller.addError(e, st);
-        }
-      });
-    };
-
-    controller.onCancel = () async {
-      cancelled = true;
-      final id = subId;
-      if (id == null) return;
-      await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
-    };
-
-    return controller.stream;
+    return _observeSubscription<T>(
+      subscribe: () => rs_runtime.request(
+        handle: _handle,
+        name: name,
+        variablesJson: variablesJson,
+        executionPolicy: executionPolicy,
+        retryDelay: retryDelay._toInput(),
+        refetchIntervalMs: autoRefetch != null
+            ? BigInt.from(autoRefetch.inMilliseconds)
+            : null,
+      ),
+      decoder: decoder,
+      debugName: name,
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -333,46 +301,11 @@ class ShalomRuntimeClient {
     required rs_runtime.ObservedRefInput ref,
     required T Function(JsonObject) decoder,
   }) {
-    BigInt? subId;
-    var cancelled = false;
-    final controller = StreamController<GraphQLResponse<T>>();
-
-    controller.onListen = () {
-      Future.microtask(() async {
-        try {
-          subId = await rs_runtime.observeFragment(
-            handle: _handle,
-            refInput: ref,
-          );
-        } catch (e, st) {
-          if (!cancelled && !controller.isClosed) controller.addError(e, st);
-          return;
-        }
-
-        if (cancelled || controller.isClosed) {
-          final id = subId;
-          if (id != null) {
-            await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
-          }
-          return;
-        }
-
-        _bindSubscriptionStream(
-          subId: subId!,
-          controller: controller,
-          decoder: decoder,
-        );
-      });
-    };
-
-    controller.onCancel = () async {
-      cancelled = true;
-      final id = subId;
-      if (id == null) return;
-      await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
-    };
-
-    return controller.stream;
+    return _observeSubscription<T>(
+      subscribe: () =>
+          rs_runtime.observeFragment(handle: _handle, refInput: ref),
+      decoder: decoder,
+    );
   }
 
   /// Rebind an existing fragment subscription identified by [subscriptionId]
@@ -391,47 +324,14 @@ class ShalomRuntimeClient {
     required rs_runtime.ObservedRefInput newRef,
     required T Function(JsonObject) decoder,
   }) {
-    BigInt? newSubId;
-    var cancelled = false;
-    final controller = StreamController<GraphQLResponse<T>>();
-
-    controller.onListen = () {
-      Future.microtask(() async {
-        try {
-          newSubId = await rs_runtime.rebindSubscription(
-            handle: _handle,
-            subscriptionId: subscriptionId,
-            newRef: newRef,
-          );
-        } catch (e, st) {
-          if (!cancelled && !controller.isClosed) controller.addError(e, st);
-          return;
-        }
-
-        if (cancelled || controller.isClosed) {
-          final id = newSubId;
-          if (id != null) {
-            await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
-          }
-          return;
-        }
-
-        _bindSubscriptionStream(
-          subId: newSubId!,
-          controller: controller,
-          decoder: decoder,
-        );
-      });
-    };
-
-    controller.onCancel = () async {
-      cancelled = true;
-      final id = newSubId;
-      if (id == null) return;
-      await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
-    };
-
-    return controller.stream;
+    return _observeSubscription<T>(
+      subscribe: () => rs_runtime.rebindSubscription(
+        handle: _handle,
+        subscriptionId: subscriptionId,
+        newRef: newRef,
+      ),
+      decoder: decoder,
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -455,6 +355,56 @@ class ShalomRuntimeClient {
   // -------------------------------------------------------------------------
   // Private subscription helper
   // -------------------------------------------------------------------------
+
+  /// Shared plumbing for [request], [subscribeToFragment] and
+  /// [rebindFragmentSubscription]: opens a cache subscription lazily on
+  /// [StreamController.onListen] via [subscribe], tears it down again via
+  /// [rs_runtime.unsubscribe] if the stream is cancelled before or after the
+  /// subscribe call resolves, and otherwise binds it with
+  /// [_bindSubscriptionStream].
+  Stream<GraphQLResponse<T>> _observeSubscription<T>({
+    required Future<BigInt> Function() subscribe,
+    required T Function(JsonObject) decoder,
+    String? debugName,
+  }) {
+    BigInt? subId;
+    var cancelled = false;
+    final controller = StreamController<GraphQLResponse<T>>();
+
+    controller.onListen = () {
+      Future.microtask(() async {
+        try {
+          subId = await subscribe();
+          if (cancelled || controller.isClosed) {
+            if (subId != null) {
+              await rs_runtime.unsubscribe(
+                handle: _handle,
+                subscriptionId: subId!,
+              );
+            }
+            return;
+          }
+          _bindSubscriptionStream(
+            subId: subId!,
+            controller: controller,
+            decoder: decoder,
+            debugName: debugName,
+          );
+        } catch (e, st) {
+          if (!cancelled && !controller.isClosed) controller.addError(e, st);
+        }
+      });
+    };
+
+    controller.onCancel = () async {
+      cancelled = true;
+      final id = subId;
+      if (id == null) return;
+      await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
+    };
+
+    return controller.stream;
+  }
 
   void _bindSubscriptionStream<T>({
     required BigInt subId,

--- a/dart/shalom/lib/src/runtime_client.dart
+++ b/dart/shalom/lib/src/runtime_client.dart
@@ -228,6 +228,7 @@ class ShalomRuntimeClient {
   }) {
     final variablesJson = variables == null ? null : jsonEncode(variables);
     BigInt? subId;
+    var cancelled = false;
     final controller = StreamController<GraphQLResponse<T>>();
 
     controller.onListen = () {
@@ -243,7 +244,7 @@ class ShalomRuntimeClient {
                 ? BigInt.from(autoRefetch.inMilliseconds)
                 : null,
           );
-          if (controller.isClosed) {
+          if (cancelled || controller.isClosed) {
             if (subId != null) {
               await rs_runtime.unsubscribe(
                 handle: _handle,
@@ -259,12 +260,13 @@ class ShalomRuntimeClient {
             debugName: name,
           );
         } catch (e, st) {
-          if (!controller.isClosed) controller.addError(e, st);
+          if (!cancelled && !controller.isClosed) controller.addError(e, st);
         }
       });
     };
 
     controller.onCancel = () async {
+      cancelled = true;
       final id = subId;
       if (id == null) return;
       await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
@@ -332,6 +334,7 @@ class ShalomRuntimeClient {
     required T Function(JsonObject) decoder,
   }) {
     BigInt? subId;
+    var cancelled = false;
     final controller = StreamController<GraphQLResponse<T>>();
 
     controller.onListen = () {
@@ -342,11 +345,11 @@ class ShalomRuntimeClient {
             refInput: ref,
           );
         } catch (e, st) {
-          if (!controller.isClosed) controller.addError(e, st);
+          if (!cancelled && !controller.isClosed) controller.addError(e, st);
           return;
         }
 
-        if (controller.isClosed) {
+        if (cancelled || controller.isClosed) {
           final id = subId;
           if (id != null) {
             await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
@@ -363,6 +366,7 @@ class ShalomRuntimeClient {
     };
 
     controller.onCancel = () async {
+      cancelled = true;
       final id = subId;
       if (id == null) return;
       await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
@@ -388,6 +392,7 @@ class ShalomRuntimeClient {
     required T Function(JsonObject) decoder,
   }) {
     BigInt? newSubId;
+    var cancelled = false;
     final controller = StreamController<GraphQLResponse<T>>();
 
     controller.onListen = () {
@@ -399,11 +404,11 @@ class ShalomRuntimeClient {
             newRef: newRef,
           );
         } catch (e, st) {
-          if (!controller.isClosed) controller.addError(e, st);
+          if (!cancelled && !controller.isClosed) controller.addError(e, st);
           return;
         }
 
-        if (controller.isClosed) {
+        if (cancelled || controller.isClosed) {
           final id = newSubId;
           if (id != null) {
             await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
@@ -420,6 +425,7 @@ class ShalomRuntimeClient {
     };
 
     controller.onCancel = () async {
+      cancelled = true;
       final id = newSubId;
       if (id == null) return;
       await rs_runtime.unsubscribe(handle: _handle, subscriptionId: id);
@@ -531,13 +537,30 @@ class ShalomRuntimeClient {
       opName: envelope.operationName,
     );
 
+    var pendingDispatch = Future<void>.value();
+
+    void enqueueDispatch(Future<void> Function() dispatch) {
+      pendingDispatch = pendingDispatch
+          .catchError((_) {})
+          .then((_) {
+            if (_disposed) return null;
+            return dispatch();
+          })
+          .catchError((_) {});
+    }
+
     final subscription = _link
         .request(request: request)
         .listen(
-          (response) async => _dispatchResponse(envelope.id, response),
-          onError: (error) async => _dispatchTransportError(envelope.id, error),
+          (response) =>
+              enqueueDispatch(() => _dispatchResponse(envelope.id, response)),
+          onError: (error) => enqueueDispatch(
+            () => _dispatchTransportError(envelope.id, error),
+          ),
           onDone: () async {
+            await pendingDispatch.catchError((_) {});
             _activeRequests.remove(envelope.id);
+            if (_disposed) return;
             await rs_runtime.completeTransport(
               handle: _handle,
               requestId: BigInt.from(envelope.id),

--- a/dart/shalom/test/runtime_test.dart
+++ b/dart/shalom/test/runtime_test.dart
@@ -36,6 +36,16 @@ class _MockLink extends GraphQLLink {
   }
 }
 
+class _NeverLink extends GraphQLLink {
+  @override
+  Stream<GraphQLResponse<JsonObject>> request({
+    required Request request,
+    HeadersType? headers,
+  }) {
+    return const Stream.empty();
+  }
+}
+
 T _expectData<T>(GraphQLResponse<T> response) {
   switch (response) {
     case GraphQLData(data: final data):
@@ -99,6 +109,52 @@ void main() {
 
   test('runtime initialises without error', () async {
     final client = _makeClient([]);
+    await client.dispose();
+  });
+
+  test(
+    'immediate request cancellation does not leave active observer',
+    () async {
+      final client = ShalomRuntimeClient.create(
+        schemaSdl: _schemaSdl,
+        link: _NeverLink(),
+      );
+      const query = 'query GetUser @observe { user(id: "1") { id name } }';
+      client.registerOperation(document: query);
+
+      final sub = client
+          .request<JsonObject>(
+            name: 'GetUser',
+            decoder: (d) => (d['user'] as Map<String, dynamic>?) ?? {},
+          )
+          .listen((_) {});
+
+      await sub.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(await client.getAllObservers(), isEmpty);
+
+      await client.dispose();
+    },
+  );
+
+  test('one-shot responses are pushed before transport completion', () async {
+    final client = _makeClient([
+      for (var i = 0; i < 20; i++)
+        GraphQLData(data: {'version': '${'v' * 50000}-$i'}),
+    ]);
+    const query = 'query GetVersion @observe { version }';
+    client.registerOperation(document: query);
+
+    for (var i = 0; i < 20; i++) {
+      final response = await client
+          .request<JsonObject>(name: 'GetVersion', decoder: (d) => d)
+          .first
+          .timeout(const Duration(seconds: 5));
+      final data = _expectData(response);
+      expect(data['version'], endsWith('-$i'));
+    }
+
     await client.dispose();
   });
 

--- a/dart/shalom_flutter/lib/shalom_flutter.dart
+++ b/dart/shalom_flutter/lib/shalom_flutter.dart
@@ -1,6 +1,7 @@
 export 'widgets/shalom_provider.dart'
     show ShalomInheritedWidget, ShalomScope, ShalomContextExtension;
 export 'src/optimistic_mutation_response.dart';
+export 'src/observable_state_mixin.dart' show ShalomObservingState;
 export 'widgets/debug_panel.dart' show ShalomDebugPanel;
 export 'widgets/observable_scope.dart'
     show

--- a/dart/shalom_flutter/lib/src/observable_state_mixin.dart
+++ b/dart/shalom_flutter/lib/src/observable_state_mixin.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:shalom/shalom.dart' show ShalomRuntimeClient, GraphQLResponse;
+import 'package:shalom_flutter/widgets/shalom_provider.dart' show ShalomScope;
+
+/// Shared subscription lifecycle for widgets that observe a stream keyed off
+/// a [ShalomRuntimeClient] resolved from [ShalomScope].
+///
+/// Resolves the client exactly once (on the first [didChangeDependencies]
+/// call) instead of on every call — `didChangeDependencies` fires on any
+/// ancestor [InheritedWidget] rebuild, not just when the client actually
+/// changes, so resubscribing there unconditionally causes spurious
+/// loading-state flicker. Call [resubscribe] explicitly whenever a widget
+/// parameter that should restart the subscription changes (e.g. from
+/// `didUpdateWidget`).
+///
+/// [_subscriptionGeneration] also guards against a stale subscription's
+/// `onDone` firing after a newer [resubscribe] call has already superseded
+/// it, which would otherwise spawn a duplicate subscription.
+mixin ShalomObservingState<TData, T extends StatefulWidget> on State<T> {
+  StreamSubscription<GraphQLResponse<TData>>? _sub;
+  late ShalomRuntimeClient _client;
+  int _subscriptionGeneration = 0;
+
+  /// Builds the stream to observe against [client].
+  Stream<GraphQLResponse<TData>> observe(ShalomRuntimeClient client);
+
+  /// Handles each emitted response (typically via `setState`).
+  void onResponse(GraphQLResponse<TData> response);
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      resubscribe();
+    }
+  }
+
+  /// Cancels any existing subscription and starts a new one against the
+  /// resolved client. Safe to call multiple times.
+  @protected
+  void resubscribe() {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
+    _sub = observe(_client).listen(
+      (response) {
+        if (generation != _subscriptionGeneration) return;
+        onResponse(response);
+      },
+      onDone: () {
+        if (mounted && generation == _subscriptionGeneration) {
+          resubscribe();
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/dart/shalom_flutter/lib/widgets/observable_scope.dart
+++ b/dart/shalom_flutter/lib/widgets/observable_scope.dart
@@ -10,14 +10,14 @@ import 'package:shalom/shalom.dart'
         LinkExceptionResponse;
 import 'package:shalom_flutter/widgets/shalom_provider.dart' show ShalomScope;
 
-typedef ShalomObserve<TData> =
-    Stream<GraphQLResponse<TData>> Function(ShalomRuntimeClient client);
+typedef ShalomObserve<TData> = Stream<GraphQLResponse<TData>> Function(
+    ShalomRuntimeClient client);
 
-typedef ShalomErrorBuilder =
-    Widget Function(BuildContext context, Object error);
+typedef ShalomErrorBuilder = Widget Function(
+    BuildContext context, Object error);
 
-typedef ShalomDataWidgetBuilder<TData> =
-    Widget Function(BuildContext context, TData data);
+typedef ShalomDataWidgetBuilder<TData> = Widget Function(
+    BuildContext context, TData data);
 
 class ShalomDataScope<TData> extends StatefulWidget {
   final Object identity;
@@ -77,28 +77,26 @@ class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
-    _sub = widget
-        .observe(_client)
-        .listen(
-          (response) {
-            if (generation != _subscriptionGeneration) return;
-            setState(() {
-              switch (response) {
-                case GraphQLData(data: final data):
-                  _data = data;
-                  _hasData = true;
-                  _error = null;
-                case GraphQLError() || LinkExceptionResponse():
-                  _error = response;
-              }
-            });
-          },
-          onDone: () {
-            if (mounted && generation == _subscriptionGeneration) {
-              _subscribe();
-            }
-          },
-        );
+    _sub = widget.observe(_client).listen(
+      (response) {
+        if (generation != _subscriptionGeneration) return;
+        setState(() {
+          switch (response) {
+            case GraphQLData(data: final data):
+              _data = data;
+              _hasData = true;
+              _error = null;
+            case GraphQLError() || LinkExceptionResponse():
+              _error = response;
+          }
+        });
+      },
+      onDone: () {
+        if (mounted && generation == _subscriptionGeneration) {
+          _subscribe();
+        }
+      },
+    );
   }
 
   @override

--- a/dart/shalom_flutter/lib/widgets/observable_scope.dart
+++ b/dart/shalom_flutter/lib/widgets/observable_scope.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart'
     show
@@ -8,7 +6,8 @@ import 'package:shalom/shalom.dart'
         GraphQLData,
         GraphQLError,
         LinkExceptionResponse;
-import 'package:shalom_flutter/widgets/shalom_provider.dart' show ShalomScope;
+import 'package:shalom_flutter/src/observable_state_mixin.dart'
+    show ShalomObservingState;
 
 typedef ShalomObserve<TData> = Stream<GraphQLResponse<TData>> Function(
     ShalomRuntimeClient client);
@@ -39,10 +38,8 @@ class ShalomDataScope<TData> extends StatefulWidget {
   State<ShalomDataScope<TData>> createState() => _ShalomDataScopeState<TData>();
 }
 
-class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
-  StreamSubscription<GraphQLResponse<TData>>? _sub;
-  late ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>>
+    with ShalomObservingState<TData, ShalomDataScope<TData>> {
   TData? _data;
   bool _hasData = false;
   Object? _error;
@@ -58,51 +55,29 @@ class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant ShalomDataScope<TData> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.identity != oldWidget.identity) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub = widget.observe(_client).listen(
-      (response) {
-        if (generation != _subscriptionGeneration) return;
-        setState(() {
-          switch (response) {
-            case GraphQLData(data: final data):
-              _data = data;
-              _hasData = true;
-              _error = null;
-            case GraphQLError() || LinkExceptionResponse():
-              _error = response;
-          }
-        });
-      },
-      onDone: () {
-        if (mounted && generation == _subscriptionGeneration) {
-          _subscribe();
-        }
-      },
-    );
-  }
+  @override
+  Stream<GraphQLResponse<TData>> observe(ShalomRuntimeClient client) =>
+      widget.observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(GraphQLResponse<TData> response) {
+    setState(() {
+      switch (response) {
+        case GraphQLData(data: final data):
+          _data = data;
+          _hasData = true;
+          _error = null;
+        case GraphQLError() || LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/dart/shalom_flutter/lib/widgets/observable_scope.dart
+++ b/dart/shalom_flutter/lib/widgets/observable_scope.dart
@@ -10,19 +10,14 @@ import 'package:shalom/shalom.dart'
         LinkExceptionResponse;
 import 'package:shalom_flutter/widgets/shalom_provider.dart' show ShalomScope;
 
-typedef ShalomObserve<TData> = Stream<GraphQLResponse<TData>> Function(
-  ShalomRuntimeClient client,
-);
+typedef ShalomObserve<TData> =
+    Stream<GraphQLResponse<TData>> Function(ShalomRuntimeClient client);
 
-typedef ShalomErrorBuilder = Widget Function(
-  BuildContext context,
-  Object error,
-);
+typedef ShalomErrorBuilder =
+    Widget Function(BuildContext context, Object error);
 
-typedef ShalomDataWidgetBuilder<TData> = Widget Function(
-  BuildContext context,
-  TData data,
-);
+typedef ShalomDataWidgetBuilder<TData> =
+    Widget Function(BuildContext context, TData data);
 
 class ShalomDataScope<TData> extends StatefulWidget {
   final Object identity;
@@ -46,6 +41,8 @@ class ShalomDataScope<TData> extends StatefulWidget {
 
 class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   StreamSubscription<GraphQLResponse<TData>>? _sub;
+  ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   TData? _data;
   bool _hasData = false;
   Object? _error;
@@ -63,37 +60,46 @@ class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant ShalomDataScope<TData> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.identity != oldWidget.identity) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
-    _sub = widget.observe(client).listen(
-      (response) {
-        setState(() {
-          switch (response) {
-            case GraphQLData(data: final data):
-              _data = data;
-              _hasData = true;
-              _error = null;
-            case GraphQLError() || LinkExceptionResponse():
-              _error = response;
-          }
-        });
-      },
-      onDone: () {
-        if (mounted) _subscribe();
-      },
-    );
+  void _subscribe(ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
+    _sub = widget
+        .observe(client)
+        .listen(
+          (response) {
+            if (generation != _subscriptionGeneration) return;
+            setState(() {
+              switch (response) {
+                case GraphQLData(data: final data):
+                  _data = data;
+                  _hasData = true;
+                  _error = null;
+                case GraphQLError() || LinkExceptionResponse():
+                  _error = response;
+              }
+            });
+          },
+          onDone: () {
+            if (mounted && generation == _subscriptionGeneration) {
+              _subscribe(client);
+            }
+          },
+        );
   }
 
   @override

--- a/dart/shalom_flutter/lib/widgets/observable_scope.dart
+++ b/dart/shalom_flutter/lib/widgets/observable_scope.dart
@@ -41,7 +41,7 @@ class ShalomDataScope<TData> extends StatefulWidget {
 
 class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   StreamSubscription<GraphQLResponse<TData>>? _sub;
-  ShalomRuntimeClient? _client;
+  late ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   TData? _data;
   bool _hasData = false;
@@ -60,10 +60,9 @@ class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -71,15 +70,15 @@ class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
   void didUpdateWidget(covariant ShalomDataScope<TData> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.identity != oldWidget.identity) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub = widget
-        .observe(client)
+        .observe(_client)
         .listen(
           (response) {
             if (generation != _subscriptionGeneration) return;
@@ -96,7 +95,7 @@ class _ShalomDataScopeState<TData> extends State<ShalomDataScope<TData>> {
           },
           onDone: () {
             if (mounted && generation == _subscriptionGeneration) {
-              _subscribe(client);
+              _subscribe();
             }
           },
         );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'UserCardQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -37,6 +37,8 @@ abstract class $UserCardQuery extends StatefulWidget {
 
 class _$UserCardQueryState extends State<$UserCardQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<UserCardQueryData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   UserCardQueryData? _data;
   Object? _error;
 
@@ -52,21 +54,27 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $UserCardQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         UserCardQueryObservable(
               variables: widget.variables,
@@ -78,6 +86,7 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -90,7 +99,9 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
@@ -37,7 +37,7 @@ abstract class $UserCardQuery extends StatefulWidget {
 
 class _$UserCardQueryState extends State<$UserCardQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<UserCardQueryData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   UserCardQueryData? _data;
   Object? _error;
@@ -54,10 +54,9 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -68,11 +67,11 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -83,7 +82,7 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -100,7 +99,7 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'UserCardQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -35,10 +34,8 @@ abstract class $UserCardQuery extends StatefulWidget {
   State<$UserCardQuery> createState() => _$UserCardQueryState();
 }
 
-class _$UserCardQueryState extends State<$UserCardQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<UserCardQueryData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$UserCardQueryState extends State<$UserCardQuery>
+    with ShalomObservingState<UserCardQueryData, $UserCardQuery> {
   UserCardQueryData? _data;
   Object? _error;
 
@@ -52,63 +49,38 @@ class _$UserCardQueryState extends State<$UserCardQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $UserCardQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        UserCardQueryObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<UserCardQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => UserCardQueryObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(shalom_core.GraphQLResponse<UserCardQueryData> response) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'PetQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -34,10 +33,8 @@ abstract class $PetQuery extends StatefulWidget {
   State<$PetQuery> createState() => _$PetQueryState();
 }
 
-class _$PetQueryState extends State<$PetQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<PetQueryData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$PetQueryState extends State<$PetQuery>
+    with ShalomObservingState<PetQueryData, $PetQuery> {
   PetQueryData? _data;
   Object? _error;
 
@@ -51,63 +48,38 @@ class _$PetQueryState extends State<$PetQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $PetQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        PetQueryObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<PetQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => PetQueryObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(shalom_core.GraphQLResponse<PetQueryData> response) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
@@ -36,7 +36,7 @@ abstract class $PetQuery extends StatefulWidget {
 
 class _$PetQueryState extends State<$PetQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<PetQueryData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   PetQueryData? _data;
   Object? _error;
@@ -53,10 +53,9 @@ class _$PetQueryState extends State<$PetQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -67,11 +66,11 @@ class _$PetQueryState extends State<$PetQuery> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -82,7 +81,7 @@ class _$PetQueryState extends State<$PetQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -99,7 +98,7 @@ class _$PetQueryState extends State<$PetQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'PetQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -36,6 +36,8 @@ abstract class $PetQuery extends StatefulWidget {
 
 class _$PetQueryState extends State<$PetQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<PetQueryData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   PetQueryData? _data;
   Object? _error;
 
@@ -51,21 +53,27 @@ class _$PetQueryState extends State<$PetQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $PetQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         PetQueryObservable(
               variables: widget.variables,
@@ -77,6 +85,7 @@ class _$PetQueryState extends State<$PetQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -89,7 +98,9 @@ class _$PetQueryState extends State<$PetQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'ZooAnimalsQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -34,10 +33,8 @@ abstract class $ZooAnimalsQuery extends StatefulWidget {
   State<$ZooAnimalsQuery> createState() => _$ZooAnimalsQueryState();
 }
 
-class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<ZooAnimalsQueryData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery>
+    with ShalomObservingState<ZooAnimalsQueryData, $ZooAnimalsQuery> {
   ZooAnimalsQueryData? _data;
   Object? _error;
 
@@ -51,63 +48,38 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $ZooAnimalsQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        ZooAnimalsQueryObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<ZooAnimalsQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => ZooAnimalsQueryObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(shalom_core.GraphQLResponse<ZooAnimalsQueryData> response) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'ZooAnimalsQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -36,6 +36,8 @@ abstract class $ZooAnimalsQuery extends StatefulWidget {
 
 class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<ZooAnimalsQueryData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   ZooAnimalsQueryData? _data;
   Object? _error;
 
@@ -51,21 +53,27 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $ZooAnimalsQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         ZooAnimalsQueryObservable(
               variables: widget.variables,
@@ -77,6 +85,7 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -89,7 +98,9 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.widget.shalom.dart
@@ -36,7 +36,7 @@ abstract class $ZooAnimalsQuery extends StatefulWidget {
 
 class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<ZooAnimalsQueryData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   ZooAnimalsQueryData? _data;
   Object? _error;
@@ -53,10 +53,9 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -67,11 +66,11 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -82,7 +81,7 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -99,7 +98,7 @@ class _$ZooAnimalsQueryState extends State<$ZooAnimalsQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'ZooQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -34,10 +33,8 @@ abstract class $ZooQuery extends StatefulWidget {
   State<$ZooQuery> createState() => _$ZooQueryState();
 }
 
-class _$ZooQueryState extends State<$ZooQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<ZooQueryData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$ZooQueryState extends State<$ZooQuery>
+    with ShalomObservingState<ZooQueryData, $ZooQuery> {
   ZooQueryData? _data;
   Object? _error;
 
@@ -51,63 +48,38 @@ class _$ZooQueryState extends State<$ZooQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $ZooQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        ZooQueryObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<ZooQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => ZooQueryObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(shalom_core.GraphQLResponse<ZooQueryData> response) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'ZooQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -36,6 +36,8 @@ abstract class $ZooQuery extends StatefulWidget {
 
 class _$ZooQueryState extends State<$ZooQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<ZooQueryData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   ZooQueryData? _data;
   Object? _error;
 
@@ -51,21 +53,27 @@ class _$ZooQueryState extends State<$ZooQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $ZooQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         ZooQueryObservable(
               variables: widget.variables,
@@ -77,6 +85,7 @@ class _$ZooQueryState extends State<$ZooQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -89,7 +98,9 @@ class _$ZooQueryState extends State<$ZooQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.widget.shalom.dart
@@ -36,7 +36,7 @@ abstract class $ZooQuery extends StatefulWidget {
 
 class _$ZooQueryState extends State<$ZooQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<ZooQueryData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   ZooQueryData? _data;
   Object? _error;
@@ -53,10 +53,9 @@ class _$ZooQueryState extends State<$ZooQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -67,11 +66,11 @@ class _$ZooQueryState extends State<$ZooQuery> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -82,7 +81,7 @@ class _$ZooQueryState extends State<$ZooQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -99,7 +98,7 @@ class _$ZooQueryState extends State<$ZooQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'UserWidget.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -33,10 +32,8 @@ abstract class $UserWidget extends StatefulWidget {
   State<$UserWidget> createState() => _$UserWidgetState();
 }
 
-class _$UserWidgetState extends State<$UserWidget> {
-  StreamSubscription<shalom_core.GraphQLResponse<UserWidgetData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$UserWidgetState extends State<$UserWidget>
+    with ShalomObservingState<UserWidgetData, $UserWidget> {
   UserWidgetData? _data;
   Object? _error;
 
@@ -50,63 +47,38 @@ class _$UserWidgetState extends State<$UserWidget> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $UserWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        UserWidgetObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<UserWidgetData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => UserWidgetObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(shalom_core.GraphQLResponse<UserWidgetData> response) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'UserWidget.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -35,6 +35,8 @@ abstract class $UserWidget extends StatefulWidget {
 
 class _$UserWidgetState extends State<$UserWidget> {
   StreamSubscription<shalom_core.GraphQLResponse<UserWidgetData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   UserWidgetData? _data;
   Object? _error;
 
@@ -50,21 +52,27 @@ class _$UserWidgetState extends State<$UserWidget> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $UserWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         UserWidgetObservable(
               variables: widget.variables,
@@ -76,6 +84,7 @@ class _$UserWidgetState extends State<$UserWidget> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -88,7 +97,9 @@ class _$UserWidgetState extends State<$UserWidget> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.widget.shalom.dart
@@ -35,7 +35,7 @@ abstract class $UserWidget extends StatefulWidget {
 
 class _$UserWidgetState extends State<$UserWidget> {
   StreamSubscription<shalom_core.GraphQLResponse<UserWidgetData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   UserWidgetData? _data;
   Object? _error;
@@ -52,10 +52,9 @@ class _$UserWidgetState extends State<$UserWidget> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -66,11 +65,11 @@ class _$UserWidgetState extends State<$UserWidget> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -81,7 +80,7 @@ class _$UserWidgetState extends State<$UserWidget> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -98,7 +97,7 @@ class _$UserWidgetState extends State<$UserWidget> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'ZooAnimalsContractQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -37,11 +36,12 @@ abstract class $ZooAnimalsContractQuery extends StatefulWidget {
       _$ZooAnimalsContractQueryState();
 }
 
-class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<ZooAnimalsContractQueryData>>?
-  _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery>
+    with
+        ShalomObservingState<
+          ZooAnimalsContractQueryData,
+          $ZooAnimalsContractQuery
+        > {
   ZooAnimalsContractQueryData? _data;
   Object? _error;
 
@@ -55,60 +55,37 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $ZooAnimalsContractQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        ZooAnimalsContractQueryObservable(
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+  @override
+  Stream<shalom_core.GraphQLResponse<ZooAnimalsContractQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => ZooAnimalsContractQueryObservable(
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(
+    shalom_core.GraphQLResponse<ZooAnimalsContractQueryData> response,
+  ) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
@@ -40,7 +40,7 @@ abstract class $ZooAnimalsContractQuery extends StatefulWidget {
 class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<ZooAnimalsContractQueryData>>?
   _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   ZooAnimalsContractQueryData? _data;
   Object? _error;
@@ -57,10 +57,9 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -70,11 +69,11 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -83,7 +82,7 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -100,7 +99,7 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'ZooAnimalsContractQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -40,6 +40,8 @@ abstract class $ZooAnimalsContractQuery extends StatefulWidget {
 class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<ZooAnimalsContractQueryData>>?
   _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   ZooAnimalsContractQueryData? _data;
   Object? _error;
 
@@ -55,20 +57,26 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $ZooAnimalsContractQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.executionPolicy != oldWidget.executionPolicy) {
-      _subscribe();
+    if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch) {
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         ZooAnimalsContractQueryObservable(
               executionPolicy: widget.executionPolicy,
@@ -78,6 +86,7 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -90,7 +99,9 @@ class _$ZooAnimalsContractQueryState extends State<$ZooAnimalsContractQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
@@ -35,7 +35,7 @@ abstract class $ShelterSubscription extends StatefulWidget {
 class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
   StreamSubscription<shalom_core.GraphQLResponse<ShelterSubscriptionData>>?
   _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   ShelterSubscriptionData? _data;
   Object? _error;
@@ -52,10 +52,9 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -65,11 +64,11 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -78,7 +77,7 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -95,7 +94,7 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'ShelterSubscription.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -35,6 +35,8 @@ abstract class $ShelterSubscription extends StatefulWidget {
 class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
   StreamSubscription<shalom_core.GraphQLResponse<ShelterSubscriptionData>>?
   _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   ShelterSubscriptionData? _data;
   Object? _error;
 
@@ -50,20 +52,26 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $ShelterSubscription oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.executionPolicy != oldWidget.executionPolicy) {
-      _subscribe();
+    if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch) {
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         ShelterSubscriptionObservable(
               executionPolicy: widget.executionPolicy,
@@ -73,6 +81,7 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -85,7 +94,9 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'ShelterSubscription.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -32,11 +31,8 @@ abstract class $ShelterSubscription extends StatefulWidget {
   State<$ShelterSubscription> createState() => _$ShelterSubscriptionState();
 }
 
-class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
-  StreamSubscription<shalom_core.GraphQLResponse<ShelterSubscriptionData>>?
-  _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$ShelterSubscriptionState extends State<$ShelterSubscription>
+    with ShalomObservingState<ShelterSubscriptionData, $ShelterSubscription> {
   ShelterSubscriptionData? _data;
   Object? _error;
 
@@ -50,60 +46,37 @@ class _$ShelterSubscriptionState extends State<$ShelterSubscription> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $ShelterSubscription oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        ShelterSubscriptionObservable(
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+  @override
+  Stream<shalom_core.GraphQLResponse<ShelterSubscriptionData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => ShelterSubscriptionObservable(
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(
+    shalom_core.GraphQLResponse<ShelterSubscriptionData> response,
+  ) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
@@ -34,7 +34,7 @@ abstract class $StreetSubscription extends StatefulWidget {
 
 class _$StreetSubscriptionState extends State<$StreetSubscription> {
   StreamSubscription<shalom_core.GraphQLResponse<StreetSubscriptionData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   StreetSubscriptionData? _data;
   Object? _error;
@@ -51,10 +51,9 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -64,11 +63,11 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -77,7 +76,7 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -94,7 +93,7 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'StreetSubscription.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -34,6 +34,8 @@ abstract class $StreetSubscription extends StatefulWidget {
 
 class _$StreetSubscriptionState extends State<$StreetSubscription> {
   StreamSubscription<shalom_core.GraphQLResponse<StreetSubscriptionData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   StreetSubscriptionData? _data;
   Object? _error;
 
@@ -49,20 +51,26 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $StreetSubscription oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.executionPolicy != oldWidget.executionPolicy) {
-      _subscribe();
+    if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch) {
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         StreetSubscriptionObservable(
               executionPolicy: widget.executionPolicy,
@@ -72,6 +80,7 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -84,7 +93,9 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'StreetSubscription.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -32,10 +31,8 @@ abstract class $StreetSubscription extends StatefulWidget {
   State<$StreetSubscription> createState() => _$StreetSubscriptionState();
 }
 
-class _$StreetSubscriptionState extends State<$StreetSubscription> {
-  StreamSubscription<shalom_core.GraphQLResponse<StreetSubscriptionData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$StreetSubscriptionState extends State<$StreetSubscription>
+    with ShalomObservingState<StreetSubscriptionData, $StreetSubscription> {
   StreetSubscriptionData? _data;
   Object? _error;
 
@@ -49,60 +46,37 @@ class _$StreetSubscriptionState extends State<$StreetSubscription> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $StreetSubscription oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        StreetSubscriptionObservable(
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+  @override
+  Stream<shalom_core.GraphQLResponse<StreetSubscriptionData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => StreetSubscriptionObservable(
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(
+    shalom_core.GraphQLResponse<StreetSubscriptionData> response,
+  ) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'AnimalQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -34,10 +33,8 @@ abstract class $AnimalQuery extends StatefulWidget {
   State<$AnimalQuery> createState() => _$AnimalQueryState();
 }
 
-class _$AnimalQueryState extends State<$AnimalQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<AnimalQueryData>>? _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$AnimalQueryState extends State<$AnimalQuery>
+    with ShalomObservingState<AnimalQueryData, $AnimalQuery> {
   AnimalQueryData? _data;
   Object? _error;
 
@@ -51,63 +48,38 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $AnimalQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        AnimalQueryObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<AnimalQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => AnimalQueryObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(shalom_core.GraphQLResponse<AnimalQueryData> response) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'AnimalQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -36,6 +36,8 @@ abstract class $AnimalQuery extends StatefulWidget {
 
 class _$AnimalQueryState extends State<$AnimalQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<AnimalQueryData>>? _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   AnimalQueryData? _data;
   Object? _error;
 
@@ -51,21 +53,27 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $AnimalQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         AnimalQueryObservable(
               variables: widget.variables,
@@ -77,6 +85,7 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -89,7 +98,9 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.widget.shalom.dart
@@ -36,7 +36,7 @@ abstract class $AnimalQuery extends StatefulWidget {
 
 class _$AnimalQueryState extends State<$AnimalQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<AnimalQueryData>>? _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   AnimalQueryData? _data;
   Object? _error;
@@ -53,10 +53,9 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -67,11 +66,11 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -82,7 +81,7 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -99,7 +98,7 @@ class _$AnimalQueryState extends State<$AnimalQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
@@ -3,7 +3,7 @@
 // Re-export all generated types so importers only need this file.
 export 'AnimalWithOwnerQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -37,6 +37,8 @@ abstract class $AnimalWithOwnerQuery extends StatefulWidget {
 class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<AnimalWithOwnerQueryData>>?
   _sub;
+  shalom_core.ShalomRuntimeClient? _client;
+  int _subscriptionGeneration = 0;
   AnimalWithOwnerQueryData? _data;
   Object? _error;
 
@@ -52,21 +54,27 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _subscribe();
+    final client = ShalomScope.of(context);
+    if (!identical(client, _client)) {
+      _client = client;
+      _subscribe(client);
+    }
   }
 
   @override
   void didUpdateWidget(covariant $AnimalWithOwnerQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
+        widget.retryDelay != oldWidget.retryDelay ||
+        widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      _subscribe(_client ?? ShalomScope.of(context));
     }
   }
 
-  void _subscribe() {
-    _sub?.cancel();
-    final client = ShalomScope.of(context);
+  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    final generation = ++_subscriptionGeneration;
+    unawaited(_sub?.cancel());
     _sub =
         AnimalWithOwnerQueryObservable(
               variables: widget.variables,
@@ -78,6 +86,7 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
             .observe(client)
             .listen(
               (response) {
+                if (generation != _subscriptionGeneration) return;
                 setState(() {
                   switch (response) {
                     case shalom_core.GraphQLData(data: final data):
@@ -90,7 +99,9 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
                 });
               },
               onDone: () {
-                if (mounted) _subscribe();
+                if (mounted && generation == _subscriptionGeneration) {
+                  _subscribe(client);
+                }
               },
             );
   }

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
@@ -37,7 +37,7 @@ abstract class $AnimalWithOwnerQuery extends StatefulWidget {
 class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
   StreamSubscription<shalom_core.GraphQLResponse<AnimalWithOwnerQueryData>>?
   _sub;
-  shalom_core.ShalomRuntimeClient? _client;
+  late shalom_core.ShalomRuntimeClient _client;
   int _subscriptionGeneration = 0;
   AnimalWithOwnerQueryData? _data;
   Object? _error;
@@ -54,10 +54,9 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final client = ShalomScope.of(context);
-    if (!identical(client, _client)) {
-      _client = client;
-      _subscribe(client);
+    if (_subscriptionGeneration == 0) {
+      _client = ShalomScope.of(context);
+      _subscribe();
     }
   }
 
@@ -68,11 +67,11 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe(_client ?? ShalomScope.of(context));
+      _subscribe();
     }
   }
 
-  void _subscribe(shalom_core.ShalomRuntimeClient client) {
+  void _subscribe() {
     final generation = ++_subscriptionGeneration;
     unawaited(_sub?.cancel());
     _sub =
@@ -83,7 +82,7 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
               retryDelay: widget.retryDelay,
               autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
               (response) {
                 if (generation != _subscriptionGeneration) return;
@@ -100,7 +99,7 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
               },
               onDone: () {
                 if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe(client);
+                  _subscribe();
                 }
               },
             );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.widget.shalom.dart
@@ -3,7 +3,6 @@
 // Re-export all generated types so importers only need this file.
 export 'AnimalWithOwnerQuery.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -34,11 +33,8 @@ abstract class $AnimalWithOwnerQuery extends StatefulWidget {
   State<$AnimalWithOwnerQuery> createState() => _$AnimalWithOwnerQueryState();
 }
 
-class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
-  StreamSubscription<shalom_core.GraphQLResponse<AnimalWithOwnerQueryData>>?
-  _sub;
-  late shalom_core.ShalomRuntimeClient _client;
-  int _subscriptionGeneration = 0;
+class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery>
+    with ShalomObservingState<AnimalWithOwnerQueryData, $AnimalWithOwnerQuery> {
   AnimalWithOwnerQueryData? _data;
   Object? _error;
 
@@ -52,63 +48,40 @@ class _$AnimalWithOwnerQueryState extends State<$AnimalWithOwnerQuery> {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_subscriptionGeneration == 0) {
-      _client = ShalomScope.of(context);
-      _subscribe();
-    }
-  }
-
-  @override
   void didUpdateWidget(covariant $AnimalWithOwnerQuery oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.executionPolicy != oldWidget.executionPolicy ||
         widget.retryDelay != oldWidget.retryDelay ||
         widget.autoRefetch != oldWidget.autoRefetch ||
         widget.variables != oldWidget.variables) {
-      _subscribe();
+      resubscribe();
     }
   }
 
-  void _subscribe() {
-    final generation = ++_subscriptionGeneration;
-    unawaited(_sub?.cancel());
-    _sub =
-        AnimalWithOwnerQueryObservable(
-              variables: widget.variables,
+  @override
+  Stream<shalom_core.GraphQLResponse<AnimalWithOwnerQueryData>> observe(
+    shalom_core.ShalomRuntimeClient client,
+  ) => AnimalWithOwnerQueryObservable(
+    variables: widget.variables,
 
-              executionPolicy: widget.executionPolicy,
-              retryDelay: widget.retryDelay,
-              autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-              (response) {
-                if (generation != _subscriptionGeneration) return;
-                setState(() {
-                  switch (response) {
-                    case shalom_core.GraphQLData(data: final data):
-                      _data = data;
-                      _error = null;
-                    case shalom_core.GraphQLError() ||
-                        shalom_core.LinkExceptionResponse():
-                      _error = response;
-                  }
-                });
-              },
-              onDone: () {
-                if (mounted && generation == _subscriptionGeneration) {
-                  _subscribe();
-                }
-              },
-            );
-  }
+    executionPolicy: widget.executionPolicy,
+    retryDelay: widget.retryDelay,
+    autoRefetch: widget.autoRefetch,
+  ).observe(client);
 
   @override
-  void dispose() {
-    _sub?.cancel();
-    super.dispose();
+  void onResponse(
+    shalom_core.GraphQLResponse<AnimalWithOwnerQueryData> response,
+  ) {
+    setState(() {
+      switch (response) {
+        case shalom_core.GraphQLData(data: final data):
+          _data = data;
+          _error = null;
+        case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+          _error = response;
+      }
+    });
   }
 
   @override

--- a/rust/shalom_dart_codegen/flutter_tests/test/observable_scope_test.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/test/observable_scope_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shalom/shalom.dart';
+import 'package:shalom_flutter/shalom_flutter.dart';
+import 'helpers/mock_link.dart';
+import 'helpers/test_env.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnv();
+  });
+
+  late ShalomRuntimeClient client;
+
+  setUp(() {
+    client = ShalomRuntimeClient.create(
+      schemaSdl: loadSchemaSdl(),
+      link: MockGraphQLLink([]),
+    );
+  });
+
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  testWidgets(
+    'ShalomDataScope does not resubscribe for provider generation changes',
+    (tester) async {
+      final updates = StreamController<GraphQLResponse<String>>(sync: true);
+      var subscribeCount = 0;
+
+      Widget build({required int generation}) {
+        return ShalomInheritedWidget(
+          client: client,
+          generation: generation,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: ShalomDataScope<String>(
+              identity: 'value',
+              observe: (_) {
+                subscribeCount += 1;
+                return updates.stream;
+              },
+              loadingBuilder: (_) => const Text('loading'),
+              builder: (_, data) => Text(data),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(build(generation: 0));
+
+      expect(subscribeCount, 1);
+      expect(find.text('loading'), findsOneWidget);
+
+      await tester.pumpWidget(build(generation: 1));
+
+      expect(subscribeCount, 1);
+
+      updates.add(const GraphQLData(data: 'ready'));
+      await tester.pump();
+
+      expect(find.text('ready'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+}

--- a/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
@@ -42,7 +42,7 @@ abstract class ${{ operation_name }} extends StatefulWidget {
 
 class _${{ operation_name }}State extends State<${{ operation_name }}> {
     StreamSubscription<shalom_core.GraphQLResponse<{{ operation_name }}Data>>? _sub;
-    shalom_core.ShalomRuntimeClient? _client;
+    late shalom_core.ShalomRuntimeClient _client;
     int _subscriptionGeneration = 0;
     {{ operation_name }}Data? _data;
     Object? _error;
@@ -56,10 +56,9 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
     @override
     void didChangeDependencies() {
         super.didChangeDependencies();
-        final client = ShalomScope.of(context);
-        if (!identical(client, _client)) {
-            _client = client;
-            _subscribe(client);
+        if (_subscriptionGeneration == 0) {
+            _client = ShalomScope.of(context);
+            _subscribe();
         }
     }
 
@@ -67,11 +66,11 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
     void didUpdateWidget(covariant ${{ operation_name }} oldWidget) {
         super.didUpdateWidget(oldWidget);
         if (widget.executionPolicy != oldWidget.executionPolicy || widget.retryDelay != oldWidget.retryDelay || widget.autoRefetch != oldWidget.autoRefetch{% if op_variables_exist %} || widget.variables != oldWidget.variables{% endif %}) {
-            _subscribe(_client ?? ShalomScope.of(context));
+            _subscribe();
         }
     }
 
-    void _subscribe(shalom_core.ShalomRuntimeClient client) {
+    void _subscribe() {
         final generation = ++_subscriptionGeneration;
         unawaited(_sub?.cancel());
         _sub = {{ operation_name }}Observable(
@@ -82,7 +81,7 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
                 retryDelay: widget.retryDelay,
                 autoRefetch: widget.autoRefetch,
             )
-            .observe(client)
+            .observe(_client)
             .listen(
                 (response) {
                     if (generation != _subscriptionGeneration) return;
@@ -98,7 +97,7 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
                 },
                 onDone: () {
                     if (mounted && generation == _subscriptionGeneration) {
-                        _subscribe(client);
+                        _subscribe();
                     }
                 },
             );

--- a/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
@@ -10,7 +10,6 @@
 // Re-export all generated types so importers only need this file.
 export '{{ operation_name }}.shalom.dart';
 
-import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -40,10 +39,8 @@ abstract class ${{ operation_name }} extends StatefulWidget {
     State<${{ operation_name }}> createState() => _${{ operation_name }}State();
 }
 
-class _${{ operation_name }}State extends State<${{ operation_name }}> {
-    StreamSubscription<shalom_core.GraphQLResponse<{{ operation_name }}Data>>? _sub;
-    late shalom_core.ShalomRuntimeClient _client;
-    int _subscriptionGeneration = 0;
+class _${{ operation_name }}State extends State<${{ operation_name }}>
+    with ShalomObservingState<{{ operation_name }}Data, ${{ operation_name }}> {
     {{ operation_name }}Data? _data;
     Object? _error;
 
@@ -54,59 +51,36 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
     }
 
     @override
-    void didChangeDependencies() {
-        super.didChangeDependencies();
-        if (_subscriptionGeneration == 0) {
-            _client = ShalomScope.of(context);
-            _subscribe();
-        }
-    }
-
-    @override
     void didUpdateWidget(covariant ${{ operation_name }} oldWidget) {
         super.didUpdateWidget(oldWidget);
         if (widget.executionPolicy != oldWidget.executionPolicy || widget.retryDelay != oldWidget.retryDelay || widget.autoRefetch != oldWidget.autoRefetch{% if op_variables_exist %} || widget.variables != oldWidget.variables{% endif %}) {
-            _subscribe();
+            resubscribe();
         }
     }
 
-    void _subscribe() {
-        final generation = ++_subscriptionGeneration;
-        unawaited(_sub?.cancel());
-        _sub = {{ operation_name }}Observable(
-                {% if op_variables_exist %}
-                variables: widget.variables,
-                {% endif %}
-                executionPolicy: widget.executionPolicy,
-                retryDelay: widget.retryDelay,
-                autoRefetch: widget.autoRefetch,
-            )
-            .observe(_client)
-            .listen(
-                (response) {
-                    if (generation != _subscriptionGeneration) return;
-                    setState(() {
-                        switch (response) {
-                            case shalom_core.GraphQLData(data: final data):
-                                _data = data;
-                                _error = null;
-                            case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
-                                _error = response;
-                        }
-                    });
-                },
-                onDone: () {
-                    if (mounted && generation == _subscriptionGeneration) {
-                        _subscribe();
-                    }
-                },
-            );
-    }
+    @override
+    Stream<shalom_core.GraphQLResponse<{{ operation_name }}Data>> observe(
+        shalom_core.ShalomRuntimeClient client,
+    ) => {{ operation_name }}Observable(
+            {% if op_variables_exist %}
+            variables: widget.variables,
+            {% endif %}
+            executionPolicy: widget.executionPolicy,
+            retryDelay: widget.retryDelay,
+            autoRefetch: widget.autoRefetch,
+        ).observe(client);
 
     @override
-    void dispose() {
-        _sub?.cancel();
-        super.dispose();
+    void onResponse(shalom_core.GraphQLResponse<{{ operation_name }}Data> response) {
+        setState(() {
+            switch (response) {
+                case shalom_core.GraphQLData(data: final data):
+                    _data = data;
+                    _error = null;
+                case shalom_core.GraphQLError() || shalom_core.LinkExceptionResponse():
+                    _error = response;
+            }
+        });
     }
 
     @override

--- a/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation_widget.dart.jinja
@@ -10,7 +10,7 @@
 // Re-export all generated types so importers only need this file.
 export '{{ operation_name }}.shalom.dart';
 
-import 'dart:async' show StreamSubscription;
+import 'dart:async' show StreamSubscription, unawaited;
 import 'package:flutter/widgets.dart';
 import 'package:shalom/shalom.dart' as shalom_core;
 import 'package:shalom_flutter/shalom_flutter.dart';
@@ -42,6 +42,8 @@ abstract class ${{ operation_name }} extends StatefulWidget {
 
 class _${{ operation_name }}State extends State<${{ operation_name }}> {
     StreamSubscription<shalom_core.GraphQLResponse<{{ operation_name }}Data>>? _sub;
+    shalom_core.ShalomRuntimeClient? _client;
+    int _subscriptionGeneration = 0;
     {{ operation_name }}Data? _data;
     Object? _error;
 
@@ -54,20 +56,24 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
     @override
     void didChangeDependencies() {
         super.didChangeDependencies();
-        _subscribe();
+        final client = ShalomScope.of(context);
+        if (!identical(client, _client)) {
+            _client = client;
+            _subscribe(client);
+        }
     }
 
     @override
     void didUpdateWidget(covariant ${{ operation_name }} oldWidget) {
         super.didUpdateWidget(oldWidget);
-        if (widget.executionPolicy != oldWidget.executionPolicy{% if op_variables_exist %} || widget.variables != oldWidget.variables{% endif %}) {
-            _subscribe();
+        if (widget.executionPolicy != oldWidget.executionPolicy || widget.retryDelay != oldWidget.retryDelay || widget.autoRefetch != oldWidget.autoRefetch{% if op_variables_exist %} || widget.variables != oldWidget.variables{% endif %}) {
+            _subscribe(_client ?? ShalomScope.of(context));
         }
     }
 
-    void _subscribe() {
-        _sub?.cancel();
-        final client = ShalomScope.of(context);
+    void _subscribe(shalom_core.ShalomRuntimeClient client) {
+        final generation = ++_subscriptionGeneration;
+        unawaited(_sub?.cancel());
         _sub = {{ operation_name }}Observable(
                 {% if op_variables_exist %}
                 variables: widget.variables,
@@ -79,6 +85,7 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
             .observe(client)
             .listen(
                 (response) {
+                    if (generation != _subscriptionGeneration) return;
                     setState(() {
                         switch (response) {
                             case shalom_core.GraphQLData(data: final data):
@@ -90,7 +97,9 @@ class _${{ operation_name }}State extends State<${{ operation_name }}> {
                     });
                 },
                 onDone: () {
-                    if (mounted) _subscribe();
+                    if (mounted && generation == _subscriptionGeneration) {
+                        _subscribe(client);
+                    }
                 },
             );
     }

--- a/rust/shalom_dart_codegen/tests/common/mod.rs
+++ b/rust/shalom_dart_codegen/tests/common/mod.rs
@@ -165,9 +165,10 @@ pub fn run_dart_tests_for_usecase(usecase: &str) {
         .arg(format!("test/{usecase}/test.dart"));
     info!("Running command: {dart_test:?} inside {dart_test_root:?}");
     let output = dart_test.output().unwrap();
+    let err = String::from_utf8_lossy(&output.stderr);
     let out_std = String::from_utf8_lossy(&output.stdout);
 
-    assert!(output.status.success(), "❌ Dart tests failed\n {out_std}");
+    assert!(output.status.success(), "❌ Dart tests failed\n {out_std}\n{err}");
     info!("✔️ Dart tests passed\n {out_std}");
 }
 

--- a/rust/shalom_dart_codegen/tests/common/mod.rs
+++ b/rust/shalom_dart_codegen/tests/common/mod.rs
@@ -168,7 +168,10 @@ pub fn run_dart_tests_for_usecase(usecase: &str) {
     let err = String::from_utf8_lossy(&output.stderr);
     let out_std = String::from_utf8_lossy(&output.stdout);
 
-    assert!(output.status.success(), "❌ Dart tests failed\n {out_std}\n{err}");
+    assert!(
+        output.status.success(),
+        "❌ Dart tests failed\n {out_std}\n{err}"
+    );
     info!("✔️ Dart tests passed\n {out_std}");
 }
 

--- a/rust/shalom_dart_codegen/tests/usecases_test.rs
+++ b/rust/shalom_dart_codegen/tests/usecases_test.rs
@@ -165,6 +165,11 @@ fn test_flutter_user_widget() {
 }
 
 #[test]
+fn test_flutter_observable_scope() {
+    common::run_flutter_tests("observable_scope_test.dart");
+}
+
+#[test]
 fn test_flutter_pet_widget() {
     common::run_flutter_tests("pet_widget_test.dart");
 }


### PR DESCRIPTION
## Summary by Sourcery

Prevent stale or overlapping GraphQL observation subscriptions in Flutter widgets and runtime client, ensuring proper cancellation, dispatch ordering, and observer cleanup.

Bug Fixes:
- Ensure ShalomRuntimeClient unsubscribes and stops emitting when requests are cancelled or streams are closed, avoiding leaked observers and stale updates.
- Prevent Flutter observable widgets from resubscribing when only the provider generation changes, and guard against outdated subscription callbacks after resubscribe.
- Guarantee one-shot responses are delivered before transport completion to avoid missing data in rapidly completing requests.

Enhancements:
- Update generated Flutter operation widgets and observable scope to reuse a cached ShalomRuntimeClient, track subscription generations, and safely cancel previous subscriptions without awaiting.
- Improve runtime transport dispatch by serializing response/error handling and skipping work after client disposal, increasing robustness under heavy streams.
- Expand test coverage for runtime and Flutter observable widgets, including Dart and Flutter integration tests, and enhance Dart test harness output by surfacing stderr on failure.

Tests:
- Add Dart and Flutter tests to cover observer cancellation, one-shot response timing, and ShalomDataScope behavior under provider generation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live update reliability so subscriptions cancel cleanly and don’t keep sending stale data after a view changes or closes.
  * Reduced duplicate or out-of-order updates during rapid refreshes and navigation.
  * Subscription-driven widgets now refresh more consistently when relevant settings change, including retry and auto-refresh behavior.

* **Tests**
  * Added coverage for subscription cancellation and update ordering to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->