### PR TITLE
device sleep resilient auto-reconnect

### DIFF
--- a/dart/shalom/lib/src/rust/api/ws.dart
+++ b/dart/shalom/lib/src/rust/api/ws.dart
@@ -89,6 +89,12 @@ sealed class WsLinkEvent with _$WsLinkEvent {
   const factory WsLinkEvent.pingReceived({String? payloadJson}) =
       WsLinkEvent_PingReceived;
 
+  /// Server sent a Pong — typically in response to a caller-initiated
+  /// heartbeat `ws_ping_frame()`. Caller should cancel any pending
+  /// pong-timeout timer.
+  const factory WsLinkEvent.pongReceived({String? payloadJson}) =
+      WsLinkEvent_PongReceived;
+
   /// A data / error payload arrived for `op_id`.
   /// `data_json`       — JSON object (`{"field":…}`) or null.
   /// `errors_json`     — JSON array  (`[{"message":…}]`) or null.

--- a/dart/shalom/lib/src/rust/api/ws.freezed.dart
+++ b/dart/shalom/lib/src/rust/api/ws.freezed.dart
@@ -55,12 +55,13 @@ extension WsLinkEventPatterns on WsLinkEvent {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( WsLinkEvent_Connected value)?  connected,TResult Function( WsLinkEvent_PingReceived value)?  pingReceived,TResult Function( WsLinkEvent_OperationResponse value)?  operationResponse,TResult Function( WsLinkEvent_OperationComplete value)?  operationComplete,TResult Function( WsLinkEvent_ProtocolError value)?  protocolError,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( WsLinkEvent_Connected value)?  connected,TResult Function( WsLinkEvent_PingReceived value)?  pingReceived,TResult Function( WsLinkEvent_PongReceived value)?  pongReceived,TResult Function( WsLinkEvent_OperationResponse value)?  operationResponse,TResult Function( WsLinkEvent_OperationComplete value)?  operationComplete,TResult Function( WsLinkEvent_ProtocolError value)?  protocolError,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case WsLinkEvent_Connected() when connected != null:
 return connected(_that);case WsLinkEvent_PingReceived() when pingReceived != null:
-return pingReceived(_that);case WsLinkEvent_OperationResponse() when operationResponse != null:
+return pingReceived(_that);case WsLinkEvent_PongReceived() when pongReceived != null:
+return pongReceived(_that);case WsLinkEvent_OperationResponse() when operationResponse != null:
 return operationResponse(_that);case WsLinkEvent_OperationComplete() when operationComplete != null:
 return operationComplete(_that);case WsLinkEvent_ProtocolError() when protocolError != null:
 return protocolError(_that);case _:
@@ -81,12 +82,13 @@ return protocolError(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( WsLinkEvent_Connected value)  connected,required TResult Function( WsLinkEvent_PingReceived value)  pingReceived,required TResult Function( WsLinkEvent_OperationResponse value)  operationResponse,required TResult Function( WsLinkEvent_OperationComplete value)  operationComplete,required TResult Function( WsLinkEvent_ProtocolError value)  protocolError,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( WsLinkEvent_Connected value)  connected,required TResult Function( WsLinkEvent_PingReceived value)  pingReceived,required TResult Function( WsLinkEvent_PongReceived value)  pongReceived,required TResult Function( WsLinkEvent_OperationResponse value)  operationResponse,required TResult Function( WsLinkEvent_OperationComplete value)  operationComplete,required TResult Function( WsLinkEvent_ProtocolError value)  protocolError,}){
 final _that = this;
 switch (_that) {
 case WsLinkEvent_Connected():
 return connected(_that);case WsLinkEvent_PingReceived():
-return pingReceived(_that);case WsLinkEvent_OperationResponse():
+return pingReceived(_that);case WsLinkEvent_PongReceived():
+return pongReceived(_that);case WsLinkEvent_OperationResponse():
 return operationResponse(_that);case WsLinkEvent_OperationComplete():
 return operationComplete(_that);case WsLinkEvent_ProtocolError():
 return protocolError(_that);}
@@ -103,12 +105,13 @@ return protocolError(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( WsLinkEvent_Connected value)?  connected,TResult? Function( WsLinkEvent_PingReceived value)?  pingReceived,TResult? Function( WsLinkEvent_OperationResponse value)?  operationResponse,TResult? Function( WsLinkEvent_OperationComplete value)?  operationComplete,TResult? Function( WsLinkEvent_ProtocolError value)?  protocolError,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( WsLinkEvent_Connected value)?  connected,TResult? Function( WsLinkEvent_PingReceived value)?  pingReceived,TResult? Function( WsLinkEvent_PongReceived value)?  pongReceived,TResult? Function( WsLinkEvent_OperationResponse value)?  operationResponse,TResult? Function( WsLinkEvent_OperationComplete value)?  operationComplete,TResult? Function( WsLinkEvent_ProtocolError value)?  protocolError,}){
 final _that = this;
 switch (_that) {
 case WsLinkEvent_Connected() when connected != null:
 return connected(_that);case WsLinkEvent_PingReceived() when pingReceived != null:
-return pingReceived(_that);case WsLinkEvent_OperationResponse() when operationResponse != null:
+return pingReceived(_that);case WsLinkEvent_PongReceived() when pongReceived != null:
+return pongReceived(_that);case WsLinkEvent_OperationResponse() when operationResponse != null:
 return operationResponse(_that);case WsLinkEvent_OperationComplete() when operationComplete != null:
 return operationComplete(_that);case WsLinkEvent_ProtocolError() when protocolError != null:
 return protocolError(_that);case _:
@@ -128,11 +131,12 @@ return protocolError(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  connected,TResult Function( String? payloadJson)?  pingReceived,TResult Function( String opId,  String? dataJson,  String? errorsJson,  String? extensionsJson)?  operationResponse,TResult Function( String opId)?  operationComplete,TResult Function( int code,  String reason)?  protocolError,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  connected,TResult Function( String? payloadJson)?  pingReceived,TResult Function( String? payloadJson)?  pongReceived,TResult Function( String opId,  String? dataJson,  String? errorsJson,  String? extensionsJson)?  operationResponse,TResult Function( String opId)?  operationComplete,TResult Function( int code,  String reason)?  protocolError,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case WsLinkEvent_Connected() when connected != null:
 return connected();case WsLinkEvent_PingReceived() when pingReceived != null:
-return pingReceived(_that.payloadJson);case WsLinkEvent_OperationResponse() when operationResponse != null:
+return pingReceived(_that.payloadJson);case WsLinkEvent_PongReceived() when pongReceived != null:
+return pongReceived(_that.payloadJson);case WsLinkEvent_OperationResponse() when operationResponse != null:
 return operationResponse(_that.opId,_that.dataJson,_that.errorsJson,_that.extensionsJson);case WsLinkEvent_OperationComplete() when operationComplete != null:
 return operationComplete(_that.opId);case WsLinkEvent_ProtocolError() when protocolError != null:
 return protocolError(_that.code,_that.reason);case _:
@@ -153,11 +157,12 @@ return protocolError(_that.code,_that.reason);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  connected,required TResult Function( String? payloadJson)  pingReceived,required TResult Function( String opId,  String? dataJson,  String? errorsJson,  String? extensionsJson)  operationResponse,required TResult Function( String opId)  operationComplete,required TResult Function( int code,  String reason)  protocolError,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  connected,required TResult Function( String? payloadJson)  pingReceived,required TResult Function( String? payloadJson)  pongReceived,required TResult Function( String opId,  String? dataJson,  String? errorsJson,  String? extensionsJson)  operationResponse,required TResult Function( String opId)  operationComplete,required TResult Function( int code,  String reason)  protocolError,}) {final _that = this;
 switch (_that) {
 case WsLinkEvent_Connected():
 return connected();case WsLinkEvent_PingReceived():
-return pingReceived(_that.payloadJson);case WsLinkEvent_OperationResponse():
+return pingReceived(_that.payloadJson);case WsLinkEvent_PongReceived():
+return pongReceived(_that.payloadJson);case WsLinkEvent_OperationResponse():
 return operationResponse(_that.opId,_that.dataJson,_that.errorsJson,_that.extensionsJson);case WsLinkEvent_OperationComplete():
 return operationComplete(_that.opId);case WsLinkEvent_ProtocolError():
 return protocolError(_that.code,_that.reason);}
@@ -174,11 +179,12 @@ return protocolError(_that.code,_that.reason);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  connected,TResult? Function( String? payloadJson)?  pingReceived,TResult? Function( String opId,  String? dataJson,  String? errorsJson,  String? extensionsJson)?  operationResponse,TResult? Function( String opId)?  operationComplete,TResult? Function( int code,  String reason)?  protocolError,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  connected,TResult? Function( String? payloadJson)?  pingReceived,TResult? Function( String? payloadJson)?  pongReceived,TResult? Function( String opId,  String? dataJson,  String? errorsJson,  String? extensionsJson)?  operationResponse,TResult? Function( String opId)?  operationComplete,TResult? Function( int code,  String reason)?  protocolError,}) {final _that = this;
 switch (_that) {
 case WsLinkEvent_Connected() when connected != null:
 return connected();case WsLinkEvent_PingReceived() when pingReceived != null:
-return pingReceived(_that.payloadJson);case WsLinkEvent_OperationResponse() when operationResponse != null:
+return pingReceived(_that.payloadJson);case WsLinkEvent_PongReceived() when pongReceived != null:
+return pongReceived(_that.payloadJson);case WsLinkEvent_OperationResponse() when operationResponse != null:
 return operationResponse(_that.opId,_that.dataJson,_that.errorsJson,_that.extensionsJson);case WsLinkEvent_OperationComplete() when operationComplete != null:
 return operationComplete(_that.opId);case WsLinkEvent_ProtocolError() when protocolError != null:
 return protocolError(_that.code,_that.reason);case _:
@@ -279,6 +285,72 @@ class _$WsLinkEvent_PingReceivedCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? payloadJson = freezed,}) {
   return _then(WsLinkEvent_PingReceived(
+payloadJson: freezed == payloadJson ? _self.payloadJson : payloadJson // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class WsLinkEvent_PongReceived extends WsLinkEvent {
+  const WsLinkEvent_PongReceived({this.payloadJson}): super._();
+  
+
+ final  String? payloadJson;
+
+/// Create a copy of WsLinkEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WsLinkEvent_PongReceivedCopyWith<WsLinkEvent_PongReceived> get copyWith => _$WsLinkEvent_PongReceivedCopyWithImpl<WsLinkEvent_PongReceived>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WsLinkEvent_PongReceived&&(identical(other.payloadJson, payloadJson) || other.payloadJson == payloadJson));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,payloadJson);
+
+@override
+String toString() {
+  return 'WsLinkEvent.pongReceived(payloadJson: $payloadJson)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $WsLinkEvent_PongReceivedCopyWith<$Res> implements $WsLinkEventCopyWith<$Res> {
+  factory $WsLinkEvent_PongReceivedCopyWith(WsLinkEvent_PongReceived value, $Res Function(WsLinkEvent_PongReceived) _then) = _$WsLinkEvent_PongReceivedCopyWithImpl;
+@useResult
+$Res call({
+ String? payloadJson
+});
+
+
+
+
+}
+/// @nodoc
+class _$WsLinkEvent_PongReceivedCopyWithImpl<$Res>
+    implements $WsLinkEvent_PongReceivedCopyWith<$Res> {
+  _$WsLinkEvent_PongReceivedCopyWithImpl(this._self, this._then);
+
+  final WsLinkEvent_PongReceived _self;
+  final $Res Function(WsLinkEvent_PongReceived) _then;
+
+/// Create a copy of WsLinkEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? payloadJson = freezed,}) {
+  return _then(WsLinkEvent_PongReceived(
 payloadJson: freezed == payloadJson ? _self.payloadJson : payloadJson // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/dart/shalom/lib/src/rust/frb_generated.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.dart
@@ -1858,15 +1858,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           payloadJson: dco_decode_opt_String(raw[1]),
         );
       case 2:
+        return WsLinkEvent_PongReceived(
+          payloadJson: dco_decode_opt_String(raw[1]),
+        );
+      case 3:
         return WsLinkEvent_OperationResponse(
           opId: dco_decode_String(raw[1]),
           dataJson: dco_decode_opt_String(raw[2]),
           errorsJson: dco_decode_opt_String(raw[3]),
           extensionsJson: dco_decode_opt_String(raw[4]),
         );
-      case 3:
-        return WsLinkEvent_OperationComplete(opId: dco_decode_String(raw[1]));
       case 4:
+        return WsLinkEvent_OperationComplete(opId: dco_decode_String(raw[1]));
+      case 5:
         return WsLinkEvent_ProtocolError(
           code: dco_decode_u_16(raw[1]),
           reason: dco_decode_String(raw[2]),
@@ -2264,6 +2268,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_payloadJson = sse_decode_opt_String(deserializer);
         return WsLinkEvent_PingReceived(payloadJson: var_payloadJson);
       case 2:
+        var var_payloadJson = sse_decode_opt_String(deserializer);
+        return WsLinkEvent_PongReceived(payloadJson: var_payloadJson);
+      case 3:
         var var_opId = sse_decode_String(deserializer);
         var var_dataJson = sse_decode_opt_String(deserializer);
         var var_errorsJson = sse_decode_opt_String(deserializer);
@@ -2274,10 +2281,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           errorsJson: var_errorsJson,
           extensionsJson: var_extensionsJson,
         );
-      case 3:
+      case 4:
         var var_opId = sse_decode_String(deserializer);
         return WsLinkEvent_OperationComplete(opId: var_opId);
-      case 4:
+      case 5:
         var var_code = sse_decode_u_16(deserializer);
         var var_reason = sse_decode_String(deserializer);
         return WsLinkEvent_ProtocolError(code: var_code, reason: var_reason);
@@ -2679,22 +2686,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case WsLinkEvent_PingReceived(payloadJson: final payloadJson):
         sse_encode_i_32(1, serializer);
         sse_encode_opt_String(payloadJson, serializer);
+      case WsLinkEvent_PongReceived(payloadJson: final payloadJson):
+        sse_encode_i_32(2, serializer);
+        sse_encode_opt_String(payloadJson, serializer);
       case WsLinkEvent_OperationResponse(
         opId: final opId,
         dataJson: final dataJson,
         errorsJson: final errorsJson,
         extensionsJson: final extensionsJson,
       ):
-        sse_encode_i_32(2, serializer);
+        sse_encode_i_32(3, serializer);
         sse_encode_String(opId, serializer);
         sse_encode_opt_String(dataJson, serializer);
         sse_encode_opt_String(errorsJson, serializer);
         sse_encode_opt_String(extensionsJson, serializer);
       case WsLinkEvent_OperationComplete(opId: final opId):
-        sse_encode_i_32(3, serializer);
+        sse_encode_i_32(4, serializer);
         sse_encode_String(opId, serializer);
       case WsLinkEvent_ProtocolError(code: final code, reason: final reason):
-        sse_encode_i_32(4, serializer);
+        sse_encode_i_32(5, serializer);
         sse_encode_u_16(code, serializer);
         sse_encode_String(reason, serializer);
     }

--- a/dart/shalom/lib/src/transport/ws_link.dart
+++ b/dart/shalom/lib/src/transport/ws_link.dart
@@ -26,6 +26,8 @@ class WebSocketLink extends GraphQLLink {
   final bool autoReconnect;
   final Duration connectionInitTimeout;
   final Duration reconnectTimeout;
+  final Duration heartbeatInterval;
+  final Duration heartbeatTimeout;
 
   // ── sans-IO state machine ─────────────────────────────────────────────────
   WsSansIo? _sansio;
@@ -48,6 +50,8 @@ class WebSocketLink extends GraphQLLink {
   // ── timers ────────────────────────────────────────────────────────────────
   Timer? _initTimer;
   Timer? _reconnectTimer;
+  Timer? _heartbeatTimer;
+  Timer? _pongTimeoutTimer;
 
   WebSocketLink({
     required this.transport,
@@ -57,6 +61,8 @@ class WebSocketLink extends GraphQLLink {
     this.autoReconnect = true,
     this.connectionInitTimeout = const Duration(seconds: 10),
     this.reconnectTimeout = const Duration(seconds: 5),
+    this.heartbeatInterval = const Duration(seconds: 5),
+    this.heartbeatTimeout = const Duration(seconds: 5),
   }) : connectionParamsJson = connectionParams != null
            ? json.encode(connectionParams)
            : null {
@@ -116,6 +122,7 @@ class WebSocketLink extends GraphQLLink {
   void _onDisconnected() {
     _acknowledged = false;
     _initTimer?.cancel();
+    _stopHeartbeat();
     _msgSub?.cancel();
     _msgController = null;
     _sender = null;
@@ -124,6 +131,28 @@ class WebSocketLink extends GraphQLLink {
       _reconnectTimer?.cancel();
       _reconnectTimer = Timer(reconnectTimeout, _connect);
     }
+  }
+
+  // ── heartbeat (client-initiated liveness ping/pong) ──────────────────────
+
+  void _startHeartbeat() {
+    _stopHeartbeat();
+    _heartbeatTimer = Timer.periodic(heartbeatInterval, (_) => _sendPing());
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+    _pongTimeoutTimer?.cancel();
+    _pongTimeoutTimer = null;
+  }
+
+  Future<void> _sendPing() async {
+    await _sendRaw(wsPingFrame());
+    _pongTimeoutTimer?.cancel();
+    _pongTimeoutTimer = Timer(heartbeatTimeout, () {
+      _closeTransport(4408, 'Heartbeat pong timeout');
+    });
   }
 
   // ── message handling ──────────────────────────────────────────────────────
@@ -154,9 +183,13 @@ class WebSocketLink extends GraphQLLink {
             alreadyInRust: rustKnownSet.contains(entry.key),
           );
         }
+        _startHeartbeat();
 
       case WsLinkEvent_PingReceived(:final payloadJson):
         await _sendRaw(wsPongFrame(sansio: _sansio!, payloadJson: payloadJson));
+
+      case WsLinkEvent_PongReceived():
+        _pongTimeoutTimer?.cancel();
 
       case WsLinkEvent_OperationResponse(
         :final opId,
@@ -322,6 +355,7 @@ class WebSocketLink extends GraphQLLink {
 
     _initTimer?.cancel();
     _reconnectTimer?.cancel();
+    _stopHeartbeat();
 
     for (final h in _ops.values) {
       if (!h.controller.isClosed) h.controller.close();

--- a/dart/shalom/lib/src/transport/ws_link.dart
+++ b/dart/shalom/lib/src/transport/ws_link.dart
@@ -62,7 +62,7 @@ class WebSocketLink extends GraphQLLink {
     this.connectionInitTimeout = const Duration(seconds: 10),
     this.reconnectTimeout = const Duration(seconds: 5),
     this.heartbeatInterval = const Duration(seconds: 5),
-    this.heartbeatTimeout = const Duration(seconds: 5),
+    this.heartbeatTimeout = const Duration(seconds: 3),
   }) : connectionParamsJson = connectionParams != null
            ? json.encode(connectionParams)
            : null {
@@ -148,7 +148,12 @@ class WebSocketLink extends GraphQLLink {
   }
 
   Future<void> _sendPing() async {
+    final heartbeatTimerAtSend = _heartbeatTimer;
     await _sendRaw(wsPingFrame());
+    // If the heartbeat was stopped (disconnect/dispose/reconnect) while the
+    // send was in flight, don't arm a timeout for a heartbeat cycle that no
+    // longer applies.
+    if (!identical(_heartbeatTimer, heartbeatTimerAtSend)) return;
     _pongTimeoutTimer?.cancel();
     _pongTimeoutTimer = Timer(heartbeatTimeout, () {
       _closeTransport(4408, 'Heartbeat pong timeout');

--- a/dart/shalom/rust/src/api/ws.rs
+++ b/dart/shalom/rust/src/api/ws.rs
@@ -28,6 +28,10 @@ pub enum WsLinkEvent {
     /// Server sent a Ping.  Send back the frame from `ws_pong_frame()`.
     /// `payload_json` is the raw ping payload (JSON object or null string).
     PingReceived { payload_json: Option<String> },
+    /// Server sent a Pong — typically in response to a caller-initiated
+    /// heartbeat `ws_ping_frame()`. Caller should cancel any pending
+    /// pong-timeout timer.
+    PongReceived { payload_json: Option<String> },
     /// A data / error payload arrived for `op_id`.
     /// `data_json`       — JSON object (`{"field":…}`) or null.
     /// `errors_json`     — JSON array  (`[{"message":…}]`) or null.
@@ -56,6 +60,9 @@ impl WsLinkEvent {
                 Self::Connected
             }
             WsEvent::PingReceived { payload } => Self::PingReceived {
+                payload_json: opt_value_to_json(payload),
+            },
+            WsEvent::PongReceived { payload } => Self::PongReceived {
                 payload_json: opt_value_to_json(payload),
             },
             WsEvent::OperationResponse { op_id, response } => {

--- a/dart/shalom/rust/src/frb_generated.rs
+++ b/dart/shalom/rust/src/frb_generated.rs
@@ -2422,6 +2422,12 @@ impl SseDecode for crate::api::ws::WsLinkEvent {
                 };
             }
             2 => {
+                let mut var_payloadJson = <Option<String>>::sse_decode(deserializer);
+                return crate::api::ws::WsLinkEvent::PongReceived {
+                    payload_json: var_payloadJson,
+                };
+            }
+            3 => {
                 let mut var_opId = <String>::sse_decode(deserializer);
                 let mut var_dataJson = <Option<String>>::sse_decode(deserializer);
                 let mut var_errorsJson = <Option<String>>::sse_decode(deserializer);
@@ -2433,11 +2439,11 @@ impl SseDecode for crate::api::ws::WsLinkEvent {
                     extensions_json: var_extensionsJson,
                 };
             }
-            3 => {
+            4 => {
                 let mut var_opId = <String>::sse_decode(deserializer);
                 return crate::api::ws::WsLinkEvent::OperationComplete { op_id: var_opId };
             }
-            4 => {
+            5 => {
                 let mut var_code = <u16>::sse_decode(deserializer);
                 let mut var_reason = <String>::sse_decode(deserializer);
                 return crate::api::ws::WsLinkEvent::ProtocolError {
@@ -2742,13 +2748,16 @@ impl flutter_rust_bridge::IntoDart for crate::api::ws::WsLinkEvent {
             crate::api::ws::WsLinkEvent::PingReceived { payload_json } => {
                 [1.into_dart(), payload_json.into_into_dart().into_dart()].into_dart()
             }
+            crate::api::ws::WsLinkEvent::PongReceived { payload_json } => {
+                [2.into_dart(), payload_json.into_into_dart().into_dart()].into_dart()
+            }
             crate::api::ws::WsLinkEvent::OperationResponse {
                 op_id,
                 data_json,
                 errors_json,
                 extensions_json,
             } => [
-                2.into_dart(),
+                3.into_dart(),
                 op_id.into_into_dart().into_dart(),
                 data_json.into_into_dart().into_dart(),
                 errors_json.into_into_dart().into_dart(),
@@ -2756,10 +2765,10 @@ impl flutter_rust_bridge::IntoDart for crate::api::ws::WsLinkEvent {
             ]
             .into_dart(),
             crate::api::ws::WsLinkEvent::OperationComplete { op_id } => {
-                [3.into_dart(), op_id.into_into_dart().into_dart()].into_dart()
+                [4.into_dart(), op_id.into_into_dart().into_dart()].into_dart()
             }
             crate::api::ws::WsLinkEvent::ProtocolError { code, reason } => [
-                4.into_dart(),
+                5.into_dart(),
                 code.into_into_dart().into_dart(),
                 reason.into_into_dart().into_dart(),
             ]
@@ -3098,24 +3107,28 @@ impl SseEncode for crate::api::ws::WsLinkEvent {
                 <i32>::sse_encode(1, serializer);
                 <Option<String>>::sse_encode(payload_json, serializer);
             }
+            crate::api::ws::WsLinkEvent::PongReceived { payload_json } => {
+                <i32>::sse_encode(2, serializer);
+                <Option<String>>::sse_encode(payload_json, serializer);
+            }
             crate::api::ws::WsLinkEvent::OperationResponse {
                 op_id,
                 data_json,
                 errors_json,
                 extensions_json,
             } => {
-                <i32>::sse_encode(2, serializer);
+                <i32>::sse_encode(3, serializer);
                 <String>::sse_encode(op_id, serializer);
                 <Option<String>>::sse_encode(data_json, serializer);
                 <Option<String>>::sse_encode(errors_json, serializer);
                 <Option<String>>::sse_encode(extensions_json, serializer);
             }
             crate::api::ws::WsLinkEvent::OperationComplete { op_id } => {
-                <i32>::sse_encode(3, serializer);
+                <i32>::sse_encode(4, serializer);
                 <String>::sse_encode(op_id, serializer);
             }
             crate::api::ws::WsLinkEvent::ProtocolError { code, reason } => {
-                <i32>::sse_encode(4, serializer);
+                <i32>::sse_encode(5, serializer);
                 <u16>::sse_encode(code, serializer);
                 <String>::sse_encode(reason, serializer);
             }

--- a/rust/shalom_core/src/context.rs
+++ b/rust/shalom_core/src/context.rs
@@ -38,7 +38,7 @@ impl ShalomGlobalContext {
     pub fn register_operations(&self, operations_update: HashMap<String, SharedOpCtx>) {
         let mut operations = self.operations.lock();
         let fragments = self.fragments.lock();
-        for (name, _) in operations_update.iter() {
+        for name in operations_update.keys() {
             if fragments.contains_key(name) {
                 panic!(
                     "Operation name {} conflicts with existing fragment name",
@@ -92,7 +92,7 @@ impl ShalomGlobalContext {
     ) -> anyhow::Result<()> {
         let mut fragments = self.fragments.lock();
         let operations = self.operations.lock();
-        for (name, _) in fragments_update.iter() {
+        for name in fragments_update.keys() {
             if fragments.contains_key(name) {
                 if allow_dups {
                     continue;

--- a/rust/shalom_runtime/src/sansio_protocols/ws.rs
+++ b/rust/shalom_runtime/src/sansio_protocols/ws.rs
@@ -56,6 +56,10 @@ pub enum WsEvent {
     /// Server sent a Ping; caller must send a Pong frame immediately.
     PingReceived { payload: Option<Value> },
 
+    /// Server sent a Pong — typically in response to a caller-initiated
+    /// heartbeat Ping. Caller should cancel any pending pong-timeout timer.
+    PongReceived { payload: Option<Value> },
+
     /// A response payload for a registered operation.
     OperationResponse {
         op_id: String,
@@ -95,6 +99,7 @@ enum ConnectionState {
 ///         WsEvent::OperationResponse { op_id, response } => { /* feed to HostLink */ }
 ///         WsEvent::OperationComplete { op_id } => { /* complete_transport(op_id) */ }
 ///         WsEvent::PingReceived { payload } => { ws.send(sm.pong_frame(payload)); }
+///         WsEvent::PongReceived { .. } => { /* cancel pending pong-timeout timer */ }
 ///         WsEvent::ProtocolError { code, reason } => { ws.close(code, reason); }
 ///     }
 /// }
@@ -213,10 +218,7 @@ impl WsStateMachine {
 
             IncomingMessage::Ping { payload } => Ok(vec![WsEvent::PingReceived { payload }]),
 
-            IncomingMessage::Pong { .. } => {
-                // Pong received in response to our ping — no action needed from caller.
-                Ok(vec![])
-            }
+            IncomingMessage::Pong { payload } => Ok(vec![WsEvent::PongReceived { payload }]),
 
             IncomingMessage::Next { id, payload } => {
                 if !self.operations.contains_key(&id) {
@@ -371,6 +373,15 @@ mod tests {
         let ping = json!({ "type": "ping" }).to_string();
         let events = sm.on_message(&ping).unwrap();
         assert!(matches!(&events[0], WsEvent::PingReceived { .. }));
+    }
+
+    #[test]
+    fn pong_emits_pong_received() {
+        let mut sm = WsStateMachine::new(None);
+        sm.on_message(&ack()).unwrap();
+        let pong = json!({ "type": "pong" }).to_string();
+        let events = sm.on_message(&pong).unwrap();
+        assert!(matches!(&events[0], WsEvent::PongReceived { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary by Sourcery

Add client-initiated WebSocket heartbeat support with ping/pong handling and integrate a new PongReceived event across Dart and Rust layers.

New Features:
- Introduce a WsLinkEvent.pongReceived event and propagate it through Dart and Rust bridging code.
- Add configurable WebSocket heartbeat interval/timeout with automatic ping sending and pong-timeout based reconnect/close logic.

Enhancements:
- Start and stop heartbeat lifecycle alongside connection acknowledgement, disconnection, and link disposal.
- Emit a PongReceived WsEvent from the Rust sans-IO WebSocket state machine instead of ignoring pong frames.
- Extend tests to cover PongReceived emission from the WebSocket state machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic WebSocket heartbeat monitoring.
  - Connections periodically send heartbeat pings and close when a timely pong response is not received.
  - Added configurable heartbeat interval and timeout settings, both defaulting to 5 seconds.
  - WebSocket pong responses are now surfaced, including optional payload data.

- **Bug Fixes**
  - Improved detection of unresponsive WebSocket connections.
  - Heartbeat monitoring now stops cleanly when connections disconnect or are disposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->