### PR TITLE
add operation cache eviction api

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -50,7 +50,7 @@ void main() async {
 }
 ```
 
-Runtime cache APIs are async because they cross the Flutter/Rust bridge. In generated mutation update callbacks, mark the callback `async` and `await` generated `readFrom`, `cache.readQuery`, `cache.writeQuery`, `ref.readFrom`, `cache.readFragment`, and `cache.writeFragment` calls.
+Runtime cache APIs are async because they cross the Flutter/Rust bridge. In generated mutation update callbacks, mark the callback `async` and `await` generated `readFrom`, `cache.readOperation`, `cache.writeOperation`, `cache.evictOperation`, `ref.readFrom`, `cache.readFragment`, and `cache.writeFragment` calls.
 
 ## Normalized Cache
 
@@ -112,7 +112,7 @@ Generated query/subscription APIs usually include:
 - `$ClassName`, a widget base with `buildLoading`, `buildError`, and `buildData`.
 - `ClassNameData`, nested result classes, and `ClassNameVariables` when variables exist.
 - `ClassNameObservable.observe(client)` for lower-level observation.
-- `ClassNameData.readFrom(cache)` for mutation update callbacks.
+- `ClassNameData.readFrom(cache)` and `ClassNameData.evictFrom(cache, {variables})` for mutation update callbacks.
 - `executionPolicy`, defaulting to `ExecutionPolicyInput.cacheFirst`.
 - `retryDelay` and `autoRefetch` for resilience — see [Retry And Auto-Refetch](#retry-and-auto-refetch).
 
@@ -440,7 +440,7 @@ await CreateAlbumMutation(client).executeWithCacheUpdate(
     final current = await AlbumsPageData.readFrom(cache);
     if (current == null) return;
 
-    await cache.writeQuery(
+    await cache.writeOperation(
       data: AlbumsPageData(
         albums: [
           ...current.albums,
@@ -514,10 +514,11 @@ await RemoveGifFromAlbumMutation(client).executeWithCacheUpdate(
 
 List update rules:
 
-- Use `cache.writeQuery` for root operation data.
+- Use `cache.writeOperation` for root operation data.
 - Use `cache.writeFragment` for one normalized entity's fragment data.
 - Preserve all required fields from the existing cached value when constructing replacement data.
-- `readFrom`, `readQuery`, and `readFragment` can return `null` when data is absent or incomplete.
+- `readFrom`, `readOperation`, and `readFragment` can return `null` when data is absent or incomplete.
 - Guard duplicate inserts with stable ids or unique fields.
 - Only write generated refs such as `AlbumWidgetRef.fromId(id)` after the mutation response includes enough fields to satisfy that fragment.
-- For queries with variables, pass the same variables to `readQuery`/`writeQuery`; argument values are part of the normalized field key.
+- For queries with variables, pass the same variables to `readOperation`/`writeOperation`/`evictOperation`; argument values are part of the normalized field key.
+- Use `cache.evictOperation(name: ..., variables: ...)` (or the generated `ClassNameData.evictFrom(cache, variables: ...)` shortcut) to drop a cached operation's root entry entirely instead of overwriting it — for example when a mutation invalidates a query rather than producing data to merge. It only unlinks the operation's root field(s); referenced entities are reclaimed by the next GC sweep if nothing else keeps them reachable, and it's a no-op (`false`) when nothing matched.

--- a/dart/shalom/lib/src/cache_proxy.dart
+++ b/dart/shalom/lib/src/cache_proxy.dart
@@ -15,18 +15,28 @@ class CacheProxy {
   /// Read the current cache for operation [name].
   ///
   /// Returns `null` when the data is absent or incomplete (missing refs).
-  Future<T?> readQuery<T>({
+  Future<T?> readOperation<T>({
     required String name,
     required T Function(JsonObject) decoder,
     Map<String, dynamic>? variables,
-  }) => _client.readQuery(name: name, decoder: decoder, variables: variables);
+  }) =>
+      _client.readOperation(name: name, decoder: decoder, variables: variables);
 
   /// Write [data] to the cache for its generated operation, normalizing it
   /// and notifying any active subscribers.
-  Future<void> writeQuery<T extends OperationInterface>({
+  Future<void> writeOperation<T extends OperationInterface>({
     required T data,
     Map<String, dynamic>? variables,
-  }) => _client.writeQuery(data: data, variables: variables);
+  }) => _client.writeOperation(data: data, variables: variables);
+
+  /// Evict operation [name]'s cached root field(s) (matched by [variables])
+  /// and notify any active subscribers.
+  ///
+  /// Returns `false` if no matching cache entry existed.
+  Future<bool> evictOperation({
+    required String name,
+    Map<String, dynamic>? variables,
+  }) => _client.evictOperation(name: name, variables: variables);
 
   /// Read an entity from the cache through the fragment's selection set.
   ///

--- a/dart/shalom/lib/src/runtime_client.dart
+++ b/dart/shalom/lib/src/runtime_client.dart
@@ -569,15 +569,15 @@ class ShalomRuntimeClient {
   /// Read the current cache for operation [name] and decode it as [T].
   ///
   /// Returns `null` when the data is absent or incomplete in the cache.
-  /// Use inside [CacheProxy.readQuery] or directly when you need a one-shot
-  /// cache read without opening a subscription.
-  Future<T?> readQuery<T>({
+  /// Use inside [CacheProxy.readOperation] or directly when you need a
+  /// one-shot cache read without opening a subscription.
+  Future<T?> readOperation<T>({
     required String name,
     required T Function(JsonObject) decoder,
     Map<String, dynamic>? variables,
   }) async {
     final variablesJson = variables == null ? null : jsonEncode(variables);
-    final raw = await rs_runtime.readQuery(
+    final raw = await rs_runtime.readOperation(
       handle: _handle,
       name: name,
       variablesJson: variablesJson,
@@ -593,15 +593,33 @@ class ShalomRuntimeClient {
   /// This is a permanent write (no rollback).  The typical use-case is inside
   /// a mutation's `executeWithCacheUpdate` callback to keep a cached list in
   /// sync after an add / remove mutation.
-  Future<void> writeQuery<T extends OperationInterface>({
+  Future<void> writeOperation<T extends OperationInterface>({
     required T data,
     Map<String, dynamic>? variables,
   }) {
     final variablesJson = variables == null ? null : jsonEncode(variables);
-    return rs_runtime.writeQuery(
+    return rs_runtime.writeOperation(
       handle: _handle,
       name: data.operation$Name(),
       dataJson: jsonEncode(data.toJson()),
+      variablesJson: variablesJson,
+    );
+  }
+
+  /// Evict operation [name]'s cached root field(s) (matched by [variables])
+  /// and notify any active subscribers.
+  ///
+  /// Only unlinks the operation's own root entry — entities it referenced
+  /// are reclaimed by the next GC sweep if nothing else keeps them
+  /// reachable. Returns `false` if no matching cache entry existed.
+  Future<bool> evictOperation({
+    required String name,
+    Map<String, dynamic>? variables,
+  }) {
+    final variablesJson = variables == null ? null : jsonEncode(variables);
+    return rs_runtime.evictOperation(
+      handle: _handle,
+      name: name,
       variablesJson: variablesJson,
     );
   }

--- a/dart/shalom/lib/src/rust/api/runtime.dart
+++ b/dart/shalom/lib/src/rust/api/runtime.dart
@@ -186,11 +186,11 @@ Future<void> completeTransport({
 /// Returns `None` when the data is absent or incomplete (missing refs), so
 /// callers don't need to handle partial results.  The returned string is a
 /// JSON object that matches the operation's selection shape.
-Future<String?> readQuery({
+Future<String?> readOperation({
   required RuntimeHandle handle,
   required String name,
   String? variablesJson,
-}) => RustLib.instance.api.crateApiRuntimeReadQuery(
+}) => RustLib.instance.api.crateApiRuntimeReadOperation(
   handle: handle,
   name: name,
   variablesJson: variablesJson,
@@ -202,15 +202,31 @@ Future<String?> readQuery({
 /// This is a permanent write — unlike `write_optimistic` it cannot be rolled
 /// back.  Use it inside a mutation's `executeWithCacheUpdate` callback to keep
 /// cached lists in sync after an add / remove / reorder mutation.
-Future<void> writeQuery({
+Future<void> writeOperation({
   required RuntimeHandle handle,
   required String name,
   required String dataJson,
   String? variablesJson,
-}) => RustLib.instance.api.crateApiRuntimeWriteQuery(
+}) => RustLib.instance.api.crateApiRuntimeWriteOperation(
   handle: handle,
   name: name,
   dataJson: dataJson,
+  variablesJson: variablesJson,
+);
+
+/// Evict a pre-registered operation's cached root field(s) (matched by
+/// `variables`) and notify any active subscribers.
+///
+/// Only unlinks the operation's own root entry — entities it referenced are
+/// reclaimed by the next GC sweep if nothing else keeps them reachable.
+/// Returns `false` if no matching cache entry existed.
+Future<bool> evictOperation({
+  required RuntimeHandle handle,
+  required String name,
+  String? variablesJson,
+}) => RustLib.instance.api.crateApiRuntimeEvictOperation(
+  handle: handle,
+  name: name,
   variablesJson: variablesJson,
 );
 

--- a/dart/shalom/lib/src/rust/frb_generated.dart
+++ b/dart/shalom/lib/src/rust/frb_generated.dart
@@ -67,7 +67,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -885489623;
+  int get rustContentHash => -746370478;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -85,6 +85,12 @@ abstract class RustLibApi extends BaseApi {
   });
 
   WsSansIo crateApiWsCreateWsSansIo({String? connectionParamsJson});
+
+  Future<bool> crateApiRuntimeEvictOperation({
+    required RuntimeHandle handle,
+    required String name,
+    String? variablesJson,
+  });
 
   Future<List<ObserverInfo>> crateApiRuntimeGetAllObservers({
     required RuntimeHandle handle,
@@ -147,7 +153,7 @@ abstract class RustLibApi extends BaseApi {
     required String entityKey,
   });
 
-  Future<String?> crateApiRuntimeReadQuery({
+  Future<String?> crateApiRuntimeReadOperation({
     required RuntimeHandle handle,
     required String name,
     String? variablesJson,
@@ -202,17 +208,17 @@ abstract class RustLibApi extends BaseApi {
     required String dataJson,
   });
 
-  Future<BigInt> crateApiRuntimeWriteOptimistic({
-    required RuntimeHandle handle,
-    required String opName,
-    required String dataJson,
-  });
-
-  Future<void> crateApiRuntimeWriteQuery({
+  Future<void> crateApiRuntimeWriteOperation({
     required RuntimeHandle handle,
     required String name,
     required String dataJson,
     String? variablesJson,
+  });
+
+  Future<BigInt> crateApiRuntimeWriteOptimistic({
+    required RuntimeHandle handle,
+    required String opName,
+    required String dataJson,
   });
 
   List<String> crateApiWsWsActiveOperationIds({required WsSansIo sansio});
@@ -336,6 +342,46 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<bool> crateApiRuntimeEvictOperation({
+    required RuntimeHandle handle,
+    required String name,
+    String? variablesJson,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRuntimeHandle(
+            handle,
+            serializer,
+          );
+          sse_encode_String(name, serializer);
+          sse_encode_opt_String(variablesJson, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_bool,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiRuntimeEvictOperationConstMeta,
+        argValues: [handle, name, variablesJson],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiRuntimeEvictOperationConstMeta =>
+      const TaskConstMeta(
+        debugName: "evict_operation",
+        argNames: ["handle", "name", "variablesJson"],
+      );
+
+  @override
   Future<List<ObserverInfo>> crateApiRuntimeGetAllObservers({
     required RuntimeHandle handle,
   }) {
@@ -350,7 +396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 4,
             port: port_,
           );
         },
@@ -385,7 +431,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -421,7 +467,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 6,
             port: port_,
           );
         },
@@ -456,7 +502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -492,7 +538,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -522,7 +568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -551,7 +597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(schemaSdl, serializer);
           sse_encode_opt_box_autoadd_runtime_config_input(config, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -588,7 +634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 10,
+              funcId: 11,
               port: port_,
             );
           },
@@ -631,7 +677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 11,
+              funcId: 12,
               port: port_,
             );
           },
@@ -671,7 +717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -711,7 +757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -755,7 +801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -795,7 +841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -817,7 +863,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<String?> crateApiRuntimeReadQuery({
+  Future<String?> crateApiRuntimeReadOperation({
     required RuntimeHandle handle,
     required String name,
     String? variablesJson,
@@ -835,7 +881,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -843,17 +889,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeSuccessData: sse_decode_opt_String,
           decodeErrorData: sse_decode_AnyhowException,
         ),
-        constMeta: kCrateApiRuntimeReadQueryConstMeta,
+        constMeta: kCrateApiRuntimeReadOperationConstMeta,
         argValues: [handle, name, variablesJson],
         apiImpl: this,
       ),
     );
   }
 
-  TaskConstMeta get kCrateApiRuntimeReadQueryConstMeta => const TaskConstMeta(
-    debugName: "read_query",
-    argNames: ["handle", "name", "variablesJson"],
-  );
+  TaskConstMeta get kCrateApiRuntimeReadOperationConstMeta =>
+      const TaskConstMeta(
+        debugName: "read_operation",
+        argNames: ["handle", "name", "variablesJson"],
+      );
 
   @override
   Future<BigInt> crateApiRuntimeRebindSubscription({
@@ -874,7 +921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -909,7 +956,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(document, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -942,7 +989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(document, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -975,7 +1022,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(schemaSdl, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1019,7 +1066,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1070,7 +1117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1098,7 +1145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_log_level(level, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1131,7 +1178,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1172,7 +1219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1194,47 +1241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<BigInt> crateApiRuntimeWriteOptimistic({
-    required RuntimeHandle handle,
-    required String opName,
-    required String dataJson,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRuntimeHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_String(opName, serializer);
-          sse_encode_String(dataJson, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 26,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_u_64,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-        constMeta: kCrateApiRuntimeWriteOptimisticConstMeta,
-        argValues: [handle, opName, dataJson],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiRuntimeWriteOptimisticConstMeta =>
-      const TaskConstMeta(
-        debugName: "write_optimistic",
-        argNames: ["handle", "opName", "dataJson"],
-      );
-
-  @override
-  Future<void> crateApiRuntimeWriteQuery({
+  Future<void> crateApiRuntimeWriteOperation({
     required RuntimeHandle handle,
     required String name,
     required String dataJson,
@@ -1262,17 +1269,58 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeSuccessData: sse_decode_unit,
           decodeErrorData: sse_decode_AnyhowException,
         ),
-        constMeta: kCrateApiRuntimeWriteQueryConstMeta,
+        constMeta: kCrateApiRuntimeWriteOperationConstMeta,
         argValues: [handle, name, dataJson, variablesJson],
         apiImpl: this,
       ),
     );
   }
 
-  TaskConstMeta get kCrateApiRuntimeWriteQueryConstMeta => const TaskConstMeta(
-    debugName: "write_query",
-    argNames: ["handle", "name", "dataJson", "variablesJson"],
-  );
+  TaskConstMeta get kCrateApiRuntimeWriteOperationConstMeta =>
+      const TaskConstMeta(
+        debugName: "write_operation",
+        argNames: ["handle", "name", "dataJson", "variablesJson"],
+      );
+
+  @override
+  Future<BigInt> crateApiRuntimeWriteOptimistic({
+    required RuntimeHandle handle,
+    required String opName,
+    required String dataJson,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRuntimeHandle(
+            handle,
+            serializer,
+          );
+          sse_encode_String(opName, serializer);
+          sse_encode_String(dataJson, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 28,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateApiRuntimeWriteOptimisticConstMeta,
+        argValues: [handle, opName, dataJson],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiRuntimeWriteOptimisticConstMeta =>
+      const TaskConstMeta(
+        debugName: "write_optimistic",
+        argNames: ["handle", "opName", "dataJson"],
+      );
 
   @override
   List<String> crateApiWsWsActiveOperationIds({required WsSansIo sansio}) {
@@ -1284,7 +1332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sansio,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -1317,7 +1365,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(opId, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1345,7 +1393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sansio,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1374,7 +1422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sansio,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1404,7 +1452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(raw, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_ws_link_event,
@@ -1428,7 +1476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1458,7 +1506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(payloadJson, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1486,7 +1534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sansio,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1522,7 +1570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(query, serializer);
           sse_encode_opt_String(variablesJson, serializer);
           sse_encode_opt_String(operationName, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,

--- a/dart/shalom/rust/src/api/runtime.rs
+++ b/dart/shalom/rust/src/api/runtime.rs
@@ -537,13 +537,16 @@ fn response_to_json(response: RuntimeResponse) -> anyhow::Result<String> {
 /// callers don't need to handle partial results.  The returned string is a
 /// JSON object that matches the operation's selection shape.
 #[frb]
-pub async fn read_query(
+pub async fn read_operation(
     handle: &RuntimeHandle,
     name: String,
     variables_json: Option<String>,
 ) -> anyhow::Result<Option<String>> {
     let variables = parse_variables(variables_json)?;
-    match handle.runtime.try_read_query(&name, variables.as_ref())? {
+    match handle
+        .runtime
+        .try_read_operation(&name, variables.as_ref())?
+    {
         Some(data) => Ok(Some(serde_json::to_string(&data)?)),
         None => Ok(None),
     }
@@ -556,7 +559,7 @@ pub async fn read_query(
 /// back.  Use it inside a mutation's `executeWithCacheUpdate` callback to keep
 /// cached lists in sync after an add / remove / reorder mutation.
 #[frb]
-pub async fn write_query(
+pub async fn write_operation(
     handle: &RuntimeHandle,
     name: String,
     data_json: String,
@@ -564,7 +567,25 @@ pub async fn write_query(
 ) -> anyhow::Result<()> {
     let variables = parse_variables(variables_json)?;
     let data: Value = serde_json::from_str(&data_json)?;
-    handle.runtime.write_query(&name, data, variables.as_ref())
+    handle
+        .runtime
+        .write_operation(&name, data, variables.as_ref())
+}
+
+/// Evict a pre-registered operation's cached root field(s) (matched by
+/// `variables`) and notify any active subscribers.
+///
+/// Only unlinks the operation's own root entry — entities it referenced are
+/// reclaimed by the next GC sweep if nothing else keeps them reachable.
+/// Returns `false` if no matching cache entry existed.
+#[frb]
+pub async fn evict_operation(
+    handle: &RuntimeHandle,
+    name: String,
+    variables_json: Option<String>,
+) -> anyhow::Result<bool> {
+    let variables = parse_variables(variables_json)?;
+    handle.runtime.evict_operation(&name, variables.as_ref())
 }
 
 /// Read an entity from the cache through a fragment's selection set.

--- a/dart/shalom/rust/src/frb_generated.rs
+++ b/dart/shalom/rust/src/frb_generated.rs
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -885489623;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -746370478;
 
 // Section: executor
 
@@ -141,6 +141,70 @@ fn wire__crate__api__ws__create_ws_sans_io_impl(
                     Ok(output_ok)
                 })(),
             )
+        },
+    )
+}
+fn wire__crate__api__runtime__evict_operation_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "evict_operation",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_handle = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RuntimeHandle>,
+            >>::sse_decode(&mut deserializer);
+            let api_name = <String>::sse_decode(&mut deserializer);
+            let api_variables_json = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_handle_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_handle,
+                                    0,
+                                    false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_handle_guard =
+                                        Some(api_handle.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_handle_guard = api_handle_guard.unwrap();
+                        let output_ok = crate::api::runtime::evict_operation(
+                            &*api_handle_guard,
+                            api_name,
+                            api_variables_json,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
         },
     )
 }
@@ -899,7 +963,7 @@ fn wire__crate__api__runtime__read_fragment_impl(
         },
     )
 }
-fn wire__crate__api__runtime__read_query_impl(
+fn wire__crate__api__runtime__read_operation_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -907,7 +971,7 @@ fn wire__crate__api__runtime__read_query_impl(
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "read_query",
+            debug_name: "read_operation",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
@@ -949,7 +1013,7 @@ fn wire__crate__api__runtime__read_query_impl(
                             }
                         }
                         let api_handle_guard = api_handle_guard.unwrap();
-                        let output_ok = crate::api::runtime::read_query(
+                        let output_ok = crate::api::runtime::read_operation(
                             &*api_handle_guard,
                             api_name,
                             api_variables_json,
@@ -1480,6 +1544,72 @@ fn wire__crate__api__runtime__write_fragment_impl(
         },
     )
 }
+fn wire__crate__api__runtime__write_operation_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "write_operation",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_handle = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RuntimeHandle>,
+            >>::sse_decode(&mut deserializer);
+            let api_name = <String>::sse_decode(&mut deserializer);
+            let api_data_json = <String>::sse_decode(&mut deserializer);
+            let api_variables_json = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_handle_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_handle,
+                                    0,
+                                    false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_handle_guard =
+                                        Some(api_handle.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_handle_guard = api_handle_guard.unwrap();
+                        let output_ok = crate::api::runtime::write_operation(
+                            &*api_handle_guard,
+                            api_name,
+                            api_data_json,
+                            api_variables_json,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__runtime__write_optimistic_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1534,72 +1664,6 @@ fn wire__crate__api__runtime__write_optimistic_impl(
                             &*api_handle_guard,
                             api_op_name,
                             api_data_json,
-                        )
-                        .await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__runtime__write_query_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "write_query",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<RuntimeHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_name = <String>::sse_decode(&mut deserializer);
-            let api_data_json = <String>::sse_decode(&mut deserializer);
-            let api_variables_json = <Option<String>>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let mut api_handle_guard = None;
-                        let decode_indices_ =
-                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
-                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                    &api_handle,
-                                    0,
-                                    false,
-                                )],
-                            );
-                        for i in decode_indices_ {
-                            match i {
-                                0 => {
-                                    api_handle_guard =
-                                        Some(api_handle.lockable_decode_async_ref().await)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        let api_handle_guard = api_handle_guard.unwrap();
-                        let output_ok = crate::api::runtime::write_query(
-                            &*api_handle_guard,
-                            api_name,
-                            api_data_json,
-                            api_variables_json,
                         )
                         .await?;
                         Ok(output_ok)
@@ -2468,34 +2532,35 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__runtime__complete_transport_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__runtime__get_all_observers_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__runtime__get_cache_entry_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__runtime__get_cache_keys_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__runtime__get_key_observers_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__runtime__get_observer_counts_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__runtime__init_app_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__runtime__listen_requests_impl(port, ptr, rust_vec_len, data_len),
-        11 => {
+        3 => wire__crate__api__runtime__evict_operation_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__runtime__get_all_observers_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__runtime__get_cache_entry_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__runtime__get_cache_keys_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__runtime__get_key_observers_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__runtime__get_observer_counts_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__runtime__init_app_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__runtime__listen_requests_impl(port, ptr, rust_vec_len, data_len),
+        12 => {
             wire__crate__api__runtime__listen_subscription_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__runtime__observe_fragment_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__runtime__push_response_impl(port, ptr, rust_vec_len, data_len),
-        14 => {
+        13 => wire__crate__api__runtime__observe_fragment_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__runtime__push_response_impl(port, ptr, rust_vec_len, data_len),
+        15 => {
             wire__crate__api__runtime__push_transport_error_impl(port, ptr, rust_vec_len, data_len)
         }
-        15 => wire__crate__api__runtime__read_fragment_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__runtime__read_query_impl(port, ptr, rust_vec_len, data_len),
-        17 => {
+        16 => wire__crate__api__runtime__read_fragment_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__runtime__read_operation_impl(port, ptr, rust_vec_len, data_len),
+        18 => {
             wire__crate__api__runtime__rebind_subscription_impl(port, ptr, rust_vec_len, data_len)
         }
-        21 => wire__crate__api__runtime__request_impl(port, ptr, rust_vec_len, data_len),
-        22 => {
+        22 => wire__crate__api__runtime__request_impl(port, ptr, rust_vec_len, data_len),
+        23 => {
             wire__crate__api__runtime__rollback_optimistic_impl(port, ptr, rust_vec_len, data_len)
         }
-        24 => wire__crate__api__runtime__unsubscribe_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__runtime__write_fragment_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__runtime__write_optimistic_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__runtime__write_query_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__runtime__unsubscribe_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__runtime__write_fragment_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__runtime__write_operation_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__runtime__write_optimistic_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2509,20 +2574,20 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         2 => wire__crate__api__ws__create_ws_sans_io_impl(ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__runtime__init_runtime_impl(ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__runtime__register_fragment_impl(ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__runtime__register_operation_impl(ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__runtime__reload_schema_impl(ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__runtime__set_log_level_impl(ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__ws__ws_active_operation_ids_impl(ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__ws__ws_complete_frame_impl(ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__ws__ws_connection_init_frame_impl(ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__ws__ws_is_connected_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__ws__ws_on_message_impl(ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__ws__ws_ping_frame_impl(ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__ws__ws_pong_frame_impl(ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__ws__ws_reset_impl(ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__ws__ws_subscribe_frame_impl(ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__runtime__init_runtime_impl(ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__runtime__register_fragment_impl(ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__runtime__register_operation_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__runtime__reload_schema_impl(ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__runtime__set_log_level_impl(ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__ws__ws_active_operation_ids_impl(ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__ws__ws_complete_frame_impl(ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__ws__ws_connection_init_frame_impl(ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__ws__ws_is_connected_impl(ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__ws__ws_on_message_impl(ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__ws__ws_ping_frame_impl(ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__ws__ws_pong_frame_impl(ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__ws__ws_reset_impl(ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__ws__ws_subscribe_frame_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/examples/flutter/gif_search/lib/__graphql__/AddGifToAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AddGifToAlbumMutation.mutation.shalom.dart
@@ -40,7 +40,7 @@ abstract class $AddGifToAlbumMutation {
   ///
   /// [update] receives a [CacheProxy] and the typed mutation response data.
   /// It's only called if the mutation returns successful data.
-  /// Use [CacheProxy.readQuery] / [CacheProxy.writeQuery] to read the current
+  /// Use [CacheProxy.readOperation] / [CacheProxy.writeOperation] to read the current
   /// cached value of any query and write back a modified version — the typical
   /// pattern for keeping lists in sync after an add / remove / reorder mutation.
   ///
@@ -49,12 +49,12 @@ abstract class $AddGifToAlbumMutation {
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
   ///   update: (cache, data) async {
-  ///     final current = await cache.readQuery(
+  ///     final current = await cache.readOperation(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       await cache.writeQuery(
+  ///       await cache.writeOperation(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/__graphql__/AlbumGifSearch.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AlbumGifSearch.shalom.dart
@@ -207,7 +207,7 @@ final class AlbumGifSearchData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     AlbumGifSearchVariables? variables,
   }) async {
-    return await cache.readQuery<AlbumGifSearchData>(
+    return await cache.readOperation<AlbumGifSearchData>(
       name: 'AlbumGifSearch',
       decoder: fromCache,
 

--- a/examples/flutter/gif_search/lib/__graphql__/AlbumsPage.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/AlbumsPage.shalom.dart
@@ -173,7 +173,7 @@ final class AlbumsPageData implements shalom_core.OperationInterface {
   /// Reads this operation's current cache entry through [cache], decoding
   /// it as [AlbumsPageData]. Returns `null` when absent or incomplete.
   static Future<AlbumsPageData?> readFrom(shalom_core.CacheProxy cache) async {
-    return await cache.readQuery<AlbumsPageData>(
+    return await cache.readOperation<AlbumsPageData>(
       name: 'AlbumsPage',
       decoder: fromCache,
     );

--- a/examples/flutter/gif_search/lib/__graphql__/CreateAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/CreateAlbumMutation.mutation.shalom.dart
@@ -32,7 +32,7 @@ abstract class $CreateAlbumMutation {
   ///
   /// [update] receives a [CacheProxy] and the typed mutation response data.
   /// It's only called if the mutation returns successful data.
-  /// Use [CacheProxy.readQuery] / [CacheProxy.writeQuery] to read the current
+  /// Use [CacheProxy.readOperation] / [CacheProxy.writeOperation] to read the current
   /// cached value of any query and write back a modified version — the typical
   /// pattern for keeping lists in sync after an add / remove / reorder mutation.
   ///
@@ -41,12 +41,12 @@ abstract class $CreateAlbumMutation {
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
   ///   update: (cache, data) async {
-  ///     final current = await cache.readQuery(
+  ///     final current = await cache.readOperation(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       await cache.writeQuery(
+  ///       await cache.writeOperation(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/__graphql__/DeleteAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/DeleteAlbumMutation.mutation.shalom.dart
@@ -32,7 +32,7 @@ abstract class $DeleteAlbumMutation {
   ///
   /// [update] receives a [CacheProxy] and the typed mutation response data.
   /// It's only called if the mutation returns successful data.
-  /// Use [CacheProxy.readQuery] / [CacheProxy.writeQuery] to read the current
+  /// Use [CacheProxy.readOperation] / [CacheProxy.writeOperation] to read the current
   /// cached value of any query and write back a modified version — the typical
   /// pattern for keeping lists in sync after an add / remove / reorder mutation.
   ///
@@ -41,12 +41,12 @@ abstract class $DeleteAlbumMutation {
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
   ///   update: (cache, data) async {
-  ///     final current = await cache.readQuery(
+  ///     final current = await cache.readOperation(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       await cache.writeQuery(
+  ///       await cache.writeOperation(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/__graphql__/RemoveGifFromAlbumMutation.mutation.shalom.dart
+++ b/examples/flutter/gif_search/lib/__graphql__/RemoveGifFromAlbumMutation.mutation.shalom.dart
@@ -36,7 +36,7 @@ abstract class $RemoveGifFromAlbumMutation {
   ///
   /// [update] receives a [CacheProxy] and the typed mutation response data.
   /// It's only called if the mutation returns successful data.
-  /// Use [CacheProxy.readQuery] / [CacheProxy.writeQuery] to read the current
+  /// Use [CacheProxy.readOperation] / [CacheProxy.writeOperation] to read the current
   /// cached value of any query and write back a modified version — the typical
   /// pattern for keeping lists in sync after an add / remove / reorder mutation.
   ///
@@ -45,12 +45,12 @@ abstract class $RemoveGifFromAlbumMutation {
   /// await addTodo.executeWithCacheUpdate(
   ///   input: AddTodoInput(title: 'Buy milk'),
   ///   update: (cache, data) async {
-  ///     final current = await cache.readQuery(
+  ///     final current = await cache.readOperation(
   ///       name: 'GetTodos',
   ///       decoder: GetTodosData.fromCache,
   ///     );
   ///     if (current != null) {
-  ///       await cache.writeQuery(
+  ///       await cache.writeOperation(
   ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
   ///       );
   ///     }

--- a/examples/flutter/gif_search/lib/main.dart
+++ b/examples/flutter/gif_search/lib/main.dart
@@ -154,7 +154,7 @@ class AlbumsPage extends $AlbumsPage with QueryWidgetMixin {
           final current = await AlbumsPageData.readFrom(cache);
           if (current == null) return;
           final newRef = AlbumWidgetRef.fromId(data.createAlbum.id);
-          await cache.writeQuery(
+          await cache.writeOperation(
             data: AlbumsPageData(albums: [...current.albums, newRef]),
           );
         },
@@ -258,7 +258,7 @@ class AlbumWidget extends $AlbumWidget with QueryWidgetMixin {
         final current = await AlbumsPageData.readFrom(cache);
         if (current == null) return;
         final deletedAnchor = AlbumWidgetData.entityKey(album.id);
-        await cache.writeQuery(
+        await cache.writeOperation(
           data: AlbumsPageData(
             albums: current.albums
                 .where((a) => a.anchor != deletedAnchor)

--- a/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/declarative_raw_fragments/__graphql__/UserCardQuery.shalom.dart
@@ -136,9 +136,23 @@ final class UserCardQueryData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     UserCardQueryVariables? variables,
   }) async {
-    return await cache.readQuery<UserCardQueryData>(
+    return await cache.readOperation<UserCardQueryData>(
       name: 'UserCardQuery',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    UserCardQueryVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'UserCardQuery',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/fragment/__graphql__/PetQuery.shalom.dart
@@ -126,9 +126,23 @@ final class PetQueryData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     PetQueryVariables? variables,
   }) async {
-    return await cache.readQuery<PetQueryData>(
+    return await cache.readOperation<PetQueryData>(
       name: 'PetQuery',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    PetQueryVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'PetQuery',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/list_interface_fragment/__graphql__/ZooAnimalsQuery.shalom.dart
@@ -159,9 +159,23 @@ final class ZooAnimalsQueryData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     ZooAnimalsQueryVariables? variables,
   }) async {
-    return await cache.readQuery<ZooAnimalsQueryData>(
+    return await cache.readOperation<ZooAnimalsQueryData>(
       name: 'ZooAnimalsQuery',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    ZooAnimalsQueryVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'ZooAnimalsQuery',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/nested_fragment/__graphql__/ZooQuery.shalom.dart
@@ -141,9 +141,23 @@ final class ZooQueryData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     ZooQueryVariables? variables,
   }) async {
-    return await cache.readQuery<ZooQueryData>(
+    return await cache.readOperation<ZooQueryData>(
       name: 'ZooQuery',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    ZooQueryVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'ZooQuery',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/query/__graphql__/UserWidget.shalom.dart
@@ -115,9 +115,23 @@ final class UserWidgetData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     UserWidgetVariables? variables,
   }) async {
-    return await cache.readQuery<UserWidgetData>(
+    return await cache.readOperation<UserWidgetData>(
       name: 'UserWidget',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    UserWidgetVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'UserWidget',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_contract/__graphql__/ZooAnimalsContractQuery.shalom.dart
@@ -255,10 +255,17 @@ final class ZooAnimalsContractQueryData
   static Future<ZooAnimalsContractQueryData?> readFrom(
     shalom_core.CacheProxy cache,
   ) async {
-    return await cache.readQuery<ZooAnimalsContractQueryData>(
+    return await cache.readOperation<ZooAnimalsContractQueryData>(
       name: 'ZooAnimalsContractQuery',
       decoder: fromCache,
     );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(shalom_core.CacheProxy cache) {
+    return cache.evictOperation(name: 'ZooAnimalsContractQuery');
   }
 
   shalom_core.JsonObject toJson() {

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/ShelterSubscription.shalom.dart
@@ -222,10 +222,17 @@ final class ShelterSubscriptionData implements shalom_core.OperationInterface {
   static Future<ShelterSubscriptionData?> readFrom(
     shalom_core.CacheProxy cache,
   ) async {
-    return await cache.readQuery<ShelterSubscriptionData>(
+    return await cache.readOperation<ShelterSubscriptionData>(
       name: 'ShelterSubscription',
       decoder: fromCache,
     );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(shalom_core.CacheProxy cache) {
+    return cache.evictOperation(name: 'ShelterSubscription');
   }
 
   shalom_core.JsonObject toJson() {

--- a/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/shared_fragment_subscription/__graphql__/StreetSubscription.shalom.dart
@@ -222,10 +222,17 @@ final class StreetSubscriptionData implements shalom_core.OperationInterface {
   static Future<StreetSubscriptionData?> readFrom(
     shalom_core.CacheProxy cache,
   ) async {
-    return await cache.readQuery<StreetSubscriptionData>(
+    return await cache.readOperation<StreetSubscriptionData>(
       name: 'StreetSubscription',
       decoder: fromCache,
     );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(shalom_core.CacheProxy cache) {
+    return cache.evictOperation(name: 'StreetSubscription');
   }
 
   shalom_core.JsonObject toJson() {

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment/__graphql__/AnimalQuery.shalom.dart
@@ -202,9 +202,23 @@ final class AnimalQueryData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     AnimalQueryVariables? variables,
   }) async {
-    return await cache.readQuery<AnimalQueryData>(
+    return await cache.readOperation<AnimalQueryData>(
       name: 'AnimalQuery',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    AnimalQueryVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'AnimalQuery',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.shalom.dart
+++ b/rust/shalom_dart_codegen/flutter_tests/lib/union_fragment_nested_object/__graphql__/AnimalWithOwnerQuery.shalom.dart
@@ -242,9 +242,23 @@ final class AnimalWithOwnerQueryData implements shalom_core.OperationInterface {
     shalom_core.CacheProxy cache, {
     AnimalWithOwnerQueryVariables? variables,
   }) async {
-    return await cache.readQuery<AnimalWithOwnerQueryData>(
+    return await cache.readOperation<AnimalWithOwnerQueryData>(
       name: 'AnimalWithOwnerQuery',
       decoder: fromCache,
+
+      variables: variables?.toJson(),
+    );
+  }
+
+  /// Evicts this operation's cached entry (matched by [variables]) through
+  /// [cache], notifying any active subscribers. Returns `false` if no
+  /// matching cache entry existed.
+  static Future<bool> evictFrom(
+    shalom_core.CacheProxy cache, {
+    AnimalWithOwnerQueryVariables? variables,
+  }) {
+    return cache.evictOperation(
+      name: 'AnimalWithOwnerQuery',
 
       variables: variables?.toJson(),
     );

--- a/rust/shalom_dart_codegen/templates/mutation_widget.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/mutation_widget.dart.jinja
@@ -44,7 +44,7 @@ abstract class ${{ operation_name }} {
     ///
     /// [update] receives a [CacheProxy] and the typed mutation response data.
     /// It's only called if the mutation returns successful data.
-    /// Use [CacheProxy.readQuery] / [CacheProxy.writeQuery] to read the current
+    /// Use [CacheProxy.readOperation] / [CacheProxy.writeOperation] to read the current
     /// cached value of any query and write back a modified version — the typical
     /// pattern for keeping lists in sync after an add / remove / reorder mutation.
     ///
@@ -53,12 +53,12 @@ abstract class ${{ operation_name }} {
     /// await addTodo.executeWithCacheUpdate(
     ///   input: AddTodoInput(title: 'Buy milk'),
     ///   update: (cache, data) async {
-    ///     final current = await cache.readQuery(
+    ///     final current = await cache.readOperation(
     ///       name: 'GetTodos',
     ///       decoder: GetTodosData.fromCache,
     ///     );
     ///     if (current != null) {
-    ///       await cache.writeQuery(
+    ///       await cache.writeOperation(
     ///         data: GetTodosData(todos: [...current.todos, data.addTodo!]),
     ///       );
     ///     }

--- a/rust/shalom_dart_codegen/templates/operation.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/operation.dart.jinja
@@ -116,9 +116,26 @@ final class {{ operation_name }}Data implements shalom_core.OperationInterface {
         {{ operation_name }}Variables? variables,
         }{% endif %}
     ) async {
-        return await cache.readQuery<{{ operation_name }}Data>(
+        return await cache.readOperation<{{ operation_name }}Data>(
             name: '{{ operation_name }}',
             decoder: fromCache,
+            {% if op_variables_exist %}
+            variables: variables?.toJson(),
+            {% endif %}
+        );
+    }
+
+    /// Evicts this operation's cached entry (matched by [variables]) through
+    /// [cache], notifying any active subscribers. Returns `false` if no
+    /// matching cache entry existed.
+    static Future<bool> evictFrom(
+        shalom_core.CacheProxy cache
+        {%- if op_variables_exist %}, {
+        {{ operation_name }}Variables? variables,
+        }{% endif %}
+    ) {
+        return cache.evictOperation(
+            name: '{{ operation_name }}',
             {% if op_variables_exist %}
             variables: variables?.toJson(),
             {% endif %}

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -13,7 +13,7 @@ use tokio_stream::{Stream, StreamExt};
 
 use shalom_core::context::SharedShalomGlobalContext;
 use shalom_core::entrypoint::{parse_document, parse_schema, register_fragments_from_document};
-use shalom_core::operation::context::SharedOpCtx;
+use shalom_core::operation::context::{ExecutableContext, SharedOpCtx};
 use shalom_core::operation::fragments::SharedFragmentContext;
 use shalom_core::shalom_config::ShalomConfig;
 
@@ -25,6 +25,7 @@ use crate::read::CacheReader;
 use crate::sansio_protocols::{
     GraphQLLink, GraphQLResponse, OperationType as LinkOperationType, Request,
 };
+use crate::selection::{field_cache_key, field_path_segment, resolve_object_selections};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -923,7 +924,7 @@ impl ShalomRuntime {
 
     /// Read the cache for a named operation. Returns `None` when data is absent
     /// or incomplete (missing refs), so callers don't need to handle partial reads.
-    pub fn try_read_query(
+    pub fn try_read_operation(
         &self,
         op_name: &str,
         variables: Option<&Map<String, Value>>,
@@ -940,7 +941,7 @@ impl ShalomRuntime {
     /// Normalize [data] into the cache for [op_name] and notify all affected
     /// subscribers.  Unlike `write_optimistic`, this write is permanent and
     /// cannot be rolled back.
-    pub fn write_query(
+    pub fn write_operation(
         &self,
         op_name: &str,
         data: Value,
@@ -950,6 +951,52 @@ impl ShalomRuntime {
         let data = self.resolve_observed_fragment_refs(data)?;
         self.normalize(&op_ctx, data, variables)?;
         Ok(())
+    }
+
+    /// Evict operation [op_name]'s root field(s) (matched with [variables])
+    /// from the cache and notify affected subscribers. This only unlinks the
+    /// operation's root entry(ies) — entities it referenced are reclaimed by
+    /// the next GC sweep if nothing else keeps them reachable.
+    ///
+    /// Returns `false` (and does nothing) if no matching cache entry exists.
+    pub fn evict_operation(
+        &self,
+        op_name: &str,
+        variables: Option<&Map<String, Value>>,
+    ) -> anyhow::Result<bool> {
+        let op_ctx = self.operation_by_name(op_name)?;
+        let root_key = match op_ctx.op_type() {
+            shalom_core::operation::types::OperationType::Query => "ROOT_QUERY",
+            shalom_core::operation::types::OperationType::Mutation => "ROOT_MUTATION",
+            shalom_core::operation::types::OperationType::Subscription => "ROOT_SUBSCRIPTION",
+        };
+        let selections = resolve_object_selections(op_ctx.get_root(), &self.engine.global_ctx());
+
+        let mut changed = HashSet::new();
+        {
+            let cache = self.cache();
+            let mut cache = cache.lock();
+            if let Some(record) = cache.get_mut(root_key) {
+                for selection in &selections {
+                    let field_name = selection.self_selection_name();
+                    if field_name == "__typename" {
+                        continue;
+                    }
+                    let cache_key = field_cache_key(field_name, &selection.arguments, variables);
+                    let field_segment =
+                        field_path_segment(field_name, &selection.arguments, variables);
+                    if record.remove(&cache_key).is_some() {
+                        changed.insert(format!("{root_key}.{field_segment}"));
+                    }
+                }
+            }
+        }
+
+        if changed.is_empty() {
+            return Ok(false);
+        }
+        self.notify_subscribers(&changed)?;
+        Ok(true)
     }
 
     /// Look up a pre-registered (or remembered) operation by name.

--- a/rust/shalom_runtime/tests/mutation.rs
+++ b/rust/shalom_runtime/tests/mutation.rs
@@ -252,7 +252,7 @@ fn write_optimistic_absent_key_rolls_back_to_absent() {
 }
 
 #[test]
-fn write_query_resolves_wrapped_observed_fragment_refs() {
+fn write_operation_resolves_wrapped_observed_fragment_refs() {
     let schema = r#"
         type Query { observedUsers: [User!]!, users: [User!]! }
         type User { id: ID!, name: String! }
@@ -283,16 +283,16 @@ fn write_query_resolves_wrapped_observed_fragment_refs() {
     let user_ref = observed["observedUsers"][0]["$UserRow"].clone();
 
     runtime
-        .write_query("Users", json!({ "users": [user_ref] }), None)
+        .write_operation("Users", json!({ "users": [user_ref] }), None)
         .unwrap();
 
-    let users = runtime.try_read_query("Users", None).unwrap().unwrap();
+    let users = runtime.try_read_operation("Users", None).unwrap().unwrap();
     assert_eq!(users["users"][0]["id"], json!("1"));
     assert_eq!(users["users"][0]["name"], json!("Ada"));
 }
 
 #[test]
-fn write_query_does_not_treat_user_fields_as_observed_refs() {
+fn write_operation_does_not_treat_user_fields_as_observed_refs() {
     let schema = r#"
         type Query { boxes: [Box!]! }
         type Box { observable_id: String!, anchor: String! }
@@ -306,7 +306,7 @@ fn write_query_does_not_treat_user_fields_as_observed_refs() {
     runtime.register_operation(operation).unwrap();
 
     runtime
-        .write_query(
+        .write_operation(
             "Boxes",
             json!({
                 "boxes": [
@@ -317,7 +317,108 @@ fn write_query_does_not_treat_user_fields_as_observed_refs() {
         )
         .unwrap();
 
-    let boxes = runtime.try_read_query("Boxes", None).unwrap().unwrap();
+    let boxes = runtime.try_read_operation("Boxes", None).unwrap().unwrap();
     assert_eq!(boxes["boxes"][0]["observable_id"], json!("ordinary-field"));
     assert_eq!(boxes["boxes"][0]["anchor"], json!("ordinary-value"));
+}
+
+// ---------------------------------------------------------------------------
+// evict_operation — manual cache eviction of an operation's root field(s)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn evict_operation_removes_matching_root_field_only() {
+    let runtime = make_runtime();
+
+    runtime
+        .write_operation(
+            "GetUser",
+            json!({ "user": { "id": "1", "name": "Alice" } }),
+            Some(&vars(&[("id", json!("1"))])),
+        )
+        .unwrap();
+    runtime
+        .write_operation(
+            "GetUser",
+            json!({ "user": { "id": "2", "name": "Bob" } }),
+            Some(&vars(&[("id", json!("2"))])),
+        )
+        .unwrap();
+
+    // Evicting a non-matching set of variables is a no-op.
+    let evicted_missing = runtime
+        .evict_operation("GetUser", Some(&vars(&[("id", json!("3"))])))
+        .unwrap();
+    assert!(!evicted_missing);
+    assert!(
+        runtime
+            .try_read_operation("GetUser", Some(&vars(&[("id", json!("1"))])))
+            .unwrap()
+            .is_some()
+    );
+
+    let evicted = runtime
+        .evict_operation("GetUser", Some(&vars(&[("id", json!("1"))])))
+        .unwrap();
+    assert!(evicted);
+
+    // The evicted variant is gone, the other is untouched.
+    assert!(
+        runtime
+            .try_read_operation("GetUser", Some(&vars(&[("id", json!("1"))])))
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        runtime
+            .try_read_operation("GetUser", Some(&vars(&[("id", json!("2"))])))
+            .unwrap()
+            .unwrap()["user"]["name"],
+        json!("Bob")
+    );
+}
+
+#[test]
+fn evict_operation_updates_subscriber_tracked_refs() {
+    let runtime = make_runtime();
+    let query_op = runtime.operation_by_name("GetUser").unwrap();
+    let query_vars = vars(&[("id", json!("1"))]);
+
+    runtime
+        .normalize(
+            &query_op,
+            json!({ "user": { "id": "1", "name": "Alice" } }),
+            Some(&query_vars),
+        )
+        .expect("seed");
+    let sub_id = runtime.create_operation_subscription(
+        query_op.clone(),
+        Some(query_vars.clone()),
+        ExecutionPolicy::NetworkFirst,
+    );
+
+    // Eviction leaves the read incomplete, so — like GC and optimistic
+    // rollback — the subscriber gets no spurious "empty" push here.
+    let evicted = runtime
+        .evict_operation("GetUser", Some(&query_vars))
+        .unwrap();
+    assert!(evicted);
+    assert!(
+        runtime
+            .try_read_operation("GetUser", Some(&query_vars))
+            .unwrap()
+            .is_none()
+    );
+
+    // A subsequent write for the same key is still delivered, proving the
+    // subscriber's tracked refs survived the eviction correctly.
+    runtime
+        .normalize(
+            &query_op,
+            json!({ "user": { "id": "1", "name": "Carol" } }),
+            Some(&query_vars),
+        )
+        .expect("re-seed");
+    let update = yield_update_sync(&runtime, sub_id);
+    assert_eq!(update["user"]["name"], json!("Carol"));
 }


### PR DESCRIPTION
+ some renamings

## Summary by Sourcery

Add runtime APIs and codegen support for evicting cached operations by name/variables and rename query-specific cache APIs to operation-centric names across Rust, Dart, and generated clients.

New Features:
- Introduce a runtime-level API to evict an operation's cached root fields based on name and variables, propagating through the Rust/Dart bridge and generated Dart clients.
- Add operation-level cache eviction helpers (evictOperation / evictFrom) to CacheProxy, ShalomRuntimeClient, and generated operation data classes.

Enhancements:
- Rename readQuery/writeQuery APIs to readOperation/writeOperation across runtime, FFI bindings, Dart client, cache proxy, codegen templates, examples, and docs for consistent terminology.
- Extend writeOperation to accept variables for cache keying and adjust optimistic write APIs and tests accordingly.
- Wire the new eviction and renamed operation APIs through the Flutter Rust Bridge dispatch tables and update function IDs as needed.

Documentation:
- Update SKILL.md and inline example docs to use the new readOperation/writeOperation/evictOperation terminology and document eviction-based cache invalidation patterns.

Tests:
- Add runtime tests covering write_operation behavior and new evict_operation semantics, including interaction with subscribers and variable-scoped eviction.