### PR TITLE
[Windows] fix: codegen dart fmt command too long

### DIFF
--- a/dart/shalom_flutter/lib/widgets/debug_panel.dart
+++ b/dart/shalom_flutter/lib/widgets/debug_panel.dart
@@ -84,14 +84,12 @@ class _ShalomDebugPanelState extends State<ShalomDebugPanel> {
   String? _selectedCacheKey;
 
   final List<
-    ({
-      _PanelTab tab,
-      String? queryField,
-      String? mutationField,
-      String? cacheKey,
-    })
-  >
-  _history = [];
+      ({
+        _PanelTab tab,
+        String? queryField,
+        String? mutationField,
+        String? cacheKey,
+      })> _history = [];
 
   String _filter = '';
   Timer? _timer;
@@ -211,10 +209,10 @@ class _ShalomDebugPanelState extends State<ShalomDebugPanel> {
   }
 
   String? get _selectedItem => switch (_tab) {
-    _PanelTab.queries => _selectedQueryField,
-    _PanelTab.mutations => _selectedMutationField,
-    _PanelTab.cache => _selectedCacheKey,
-  };
+        _PanelTab.queries => _selectedQueryField,
+        _PanelTab.mutations => _selectedMutationField,
+        _PanelTab.cache => _selectedCacheKey,
+      };
 
   void _onItemSelected(String item) {
     setState(() {
@@ -532,9 +530,8 @@ class _LeftPane extends StatelessWidget {
                       final obsCount = obsCounts[item];
 
                       final parenIdx = item.indexOf('(');
-                      final displayName = parenIdx == -1
-                          ? item
-                          : item.substring(0, parenIdx);
+                      final displayName =
+                          parenIdx == -1 ? item : item.substring(0, parenIdx);
                       final hasArgs = parenIdx != -1;
 
                       return InkWell(

--- a/dart/shalom_flutter/lib/widgets/observable_scope.dart
+++ b/dart/shalom_flutter/lib/widgets/observable_scope.dart
@@ -9,14 +9,14 @@ import 'package:shalom/shalom.dart'
 import 'package:shalom_flutter/src/observable_state_mixin.dart'
     show ShalomObservingState;
 
-typedef ShalomObserve<TData> =
-    Stream<GraphQLResponse<TData>> Function(ShalomRuntimeClient client);
+typedef ShalomObserve<TData> = Stream<GraphQLResponse<TData>> Function(
+    ShalomRuntimeClient client);
 
-typedef ShalomErrorBuilder =
-    Widget Function(BuildContext context, Object error);
+typedef ShalomErrorBuilder = Widget Function(
+    BuildContext context, Object error);
 
-typedef ShalomDataWidgetBuilder<TData> =
-    Widget Function(BuildContext context, TData data);
+typedef ShalomDataWidgetBuilder<TData> = Widget Function(
+    BuildContext context, TData data);
 
 class ShalomDataScope<TData> extends StatefulWidget {
   final Object identity;

--- a/dart/shalom_flutter/lib/widgets/shalom_provider.dart
+++ b/dart/shalom_flutter/lib/widgets/shalom_provider.dart
@@ -28,8 +28,8 @@ class ShalomScope {
 
   /// Retrieves the nearest [ShalomRuntimeClient] from the given [BuildContext].
   static ShalomRuntimeClient of(BuildContext context) {
-    final result = context
-        .dependOnInheritedWidgetOfExactType<ShalomInheritedWidget>();
+    final result =
+        context.dependOnInheritedWidgetOfExactType<ShalomInheritedWidget>();
     assert(result != null, 'No ShalomProvider found in context');
     return result!.client;
   }

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -1362,7 +1362,7 @@ fn format_generated_files(pwd: &Path) -> Result<()> {
     };
 
     for file in &files {
-        let file_len = file.as_os_str().len() + 1; // +1 for separating space
+        let file_len = file.to_string_lossy().len() + 1; // +1 for separating space
         if !chunk.is_empty() && chunk_len + file_len > MAX_CMDLINE_CHARS {
             run_chunk(&chunk)?;
             chunk.clear();

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -1326,7 +1326,21 @@ fn format_generated_files(pwd: &Path) -> Result<()> {
         }
     }
 
-    for chunk in files.chunks(100) {
+    // Windows caps command lines at ~8191 chars (CreateProcess limit), so we
+    // can't just chunk by a fixed file count: generated paths can be long
+    // enough that even 100 of them blow past that limit. Chunk by the actual
+    // serialized length of the arguments instead, with headroom for the
+    // command/args themselves.
+    const MAX_CMDLINE_CHARS: usize = 6000;
+
+    let mut chunk: Vec<&PathBuf> = Vec::new();
+    let mut chunk_len = 0usize;
+
+    let run_chunk = |chunk: &[&PathBuf]| -> Result<()> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+
         let mut cmd = Command::new(dart_cmd);
 
         // Add any additional args (like "fvm" if using fvm dart)
@@ -1343,7 +1357,21 @@ fn format_generated_files(pwd: &Path) -> Result<()> {
                 String::from_utf8_lossy(&output.stderr)
             );
         }
+
+        Ok(())
+    };
+
+    for file in &files {
+        let file_len = file.as_os_str().len() + 1; // +1 for separating space
+        if !chunk.is_empty() && chunk_len + file_len > MAX_CMDLINE_CHARS {
+            run_chunk(&chunk)?;
+            chunk.clear();
+            chunk_len = 0;
+        }
+        chunk_len += file_len;
+        chunk.push(file);
     }
+    run_chunk(&chunk)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary by Sourcery

Adjust Dart formatter invocation to avoid Windows command-line length limits when formatting generated files.

Bug Fixes:
- Prevent Dart formatting command from exceeding Windows command-line length limits by chunking file arguments based on serialized length instead of a fixed count.

Enhancements:
- Apply minor Dart code style and formatting cleanups in Flutter debug and observable widgets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of large generated Dart code sets by batching files according to command-line size limits, helping prevent failures during code generation.

* **Refactor**
  * Standardized code formatting across Flutter widgets and supporting declarations without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->