### PR TITLE
fix refetch in networkFirst mode to emit warm data

### DIFF
--- a/dart/shalom/test/runtime_test.dart
+++ b/dart/shalom/test/runtime_test.dart
@@ -17,6 +17,14 @@ String get _nativeLibPath {
 
 JsonObject _json(ShalomJsonValue value) => value.toJsonValue() as JsonObject;
 
+/// [request]/[subscribeToFragment] require a [StreamCompat] type argument;
+/// wrap plain decoded JSON so these tests can use it as one.
+class _TestData extends MapView<String, dynamic> implements StreamCompat {
+  _TestData(super.map);
+}
+
+_TestData _tdJson(ShalomJsonValue value) => _TestData(_json(value));
+
 // ---------------------------------------------------------------------------
 // Inline mock link.
 // ---------------------------------------------------------------------------
@@ -167,9 +175,9 @@ void main() {
       client.registerOperation(document: query);
 
       final sub = client
-          .request<JsonObject>(
+          .request<_TestData>(
             name: 'GetUser',
-            decoder: (d) => _json(d)['user'] as JsonObject? ?? {},
+            decoder: (d) => _TestData(_json(d)['user'] as JsonObject? ?? {}),
           )
           .listen((_) {});
 
@@ -192,7 +200,7 @@ void main() {
 
     for (var i = 0; i < 20; i++) {
       final response = await client
-          .request<JsonObject>(name: 'GetVersion', decoder: _json)
+          .request<_TestData>(name: 'GetVersion', decoder: _tdJson)
           .first
           .timeout(const Duration(seconds: 5));
       final data = _expectData(response);
@@ -218,9 +226,9 @@ void main() {
     client.registerOperation(document: query);
 
     final response = await client
-        .request<JsonObject>(
+        .request<_TestData>(
           name: 'GetUser',
-          decoder: (d) => _json(d)['user'] as JsonObject? ?? {},
+          decoder: (d) => _TestData(_json(d)['user'] as JsonObject? ?? {}),
         )
         .first
         .timeout(const Duration(seconds: 5));
@@ -254,9 +262,9 @@ void main() {
     client.registerOperation(document: query);
 
     final response = await client
-        .request<JsonObject>(
+        .request<_TestData>(
           name: 'GetUser',
-          decoder: (data) => _json(data)['user'] as JsonObject,
+          decoder: (data) => _TestData(_json(data)['user'] as JsonObject),
         )
         .first
         .timeout(const Duration(seconds: 5));
@@ -315,18 +323,18 @@ void main() {
       final secondReceived = Completer<void>();
 
       final sub = client
-          .request<JsonObject>(
+          .request<_TestData>(
             name: 'GetUser',
-            decoder: (d) => _json(d)['user'] as JsonObject? ?? {},
+            decoder: (d) => _TestData(_json(d)['user'] as JsonObject? ?? {}),
           )
           .listen((response) {
             results.add(_expectData(response));
             if (results.length == 1) {
               unawaited(
                 client
-                    .request<JsonObject>(
+                    .request<_TestData>(
                       name: 'GetUserDetails',
-                      decoder: (d) => _json(d)['user'] as JsonObject? ?? {},
+                      decoder: (d) => _TestData(_json(d)['user'] as JsonObject? ?? {}),
                     )
                     .first,
               );
@@ -372,9 +380,9 @@ void main() {
     bool gotUpdate = false;
 
     final sub = client
-        .request<JsonObject>(
+        .request<_TestData>(
           name: 'GetUser',
-          decoder: (d) => _json(d)['user'] as JsonObject? ?? {},
+          decoder: (d) => _TestData(_json(d)['user'] as JsonObject? ?? {}),
         )
         .listen((data) {
           if (!firstReceived.isCompleted) {
@@ -387,9 +395,9 @@ void main() {
     await firstReceived.future.timeout(const Duration(seconds: 5));
 
     await client
-        .request<JsonObject>(
+        .request<_TestData>(
           name: 'GetPost',
-          decoder: (d) => _json(d)['post'] as JsonObject? ?? {},
+          decoder: (d) => _TestData(_json(d)['post'] as JsonObject? ?? {}),
         )
         .first
         .timeout(const Duration(seconds: 5));
@@ -454,19 +462,19 @@ void main() {
 
     // Populate the cache.
     await client
-        .request<JsonObject>(name: 'GetUser', decoder: _json)
+        .request<_TestData>(name: 'GetUser', decoder: _tdJson)
         .first
         .timeout(const Duration(seconds: 5));
 
     // Subscribe to the pet entity by its normalised cache key.
-    final petUpdates = client.subscribeToFragment<JsonObject>(
+    final petUpdates = client.subscribeToFragment<_TestData>(
       ref: ObservedRefInput(observableId: 'PetFrag', anchor: 'Pet:14'),
-      decoder: _json,
+      decoder: _tdJson,
     );
 
     // Trigger a second fetch that updates Pet:14.name to "Max".
     unawaited(
-      client.request<JsonObject>(name: 'GetUser', decoder: _json).first,
+      client.request<_TestData>(name: 'GetUser', decoder: _tdJson).first,
     );
 
     // skip(1): discard the immediate cache hit ('Rex'); await the update ('Max').
@@ -509,19 +517,19 @@ void main() {
 
       // Populate cache.
       await client
-          .request<JsonObject>(name: 'FetchUser', decoder: _json)
+          .request<_TestData>(name: 'FetchUser', decoder: _tdJson)
           .first
           .timeout(const Duration(seconds: 5));
 
       final ref = ObservedRefInput(observableId: 'UserFrag', anchor: 'User:7');
-      final updates = client.subscribeToFragment<JsonObject>(
+      final updates = client.subscribeToFragment<_TestData>(
         ref: ref,
-        decoder: _json,
+        decoder: _tdJson,
       );
 
       // Trigger the write.
       unawaited(
-        client.request<JsonObject>(name: 'FetchUser', decoder: _json).first,
+        client.request<_TestData>(name: 'FetchUser', decoder: _tdJson).first,
       );
 
       // skip(1): discard the immediate cache hit ('Initial'); await the update ('Updated').
@@ -577,18 +585,18 @@ void main() {
 
     // Populate cache for both pets.
     await client
-        .request<JsonObject>(name: 'GetPet14', decoder: _json)
+        .request<_TestData>(name: 'GetPet14', decoder: _tdJson)
         .first
         .timeout(const Duration(seconds: 5));
     await client
-        .request<JsonObject>(name: 'GetPet15', decoder: _json)
+        .request<_TestData>(name: 'GetPet15', decoder: _tdJson)
         .first
         .timeout(const Duration(seconds: 5));
 
     // Subscribe to Pet:14 via the fragment.
-    final sub14 = client.subscribeToFragment<JsonObject>(
+    final sub14 = client.subscribeToFragment<_TestData>(
       ref: ObservedRefInput(observableId: 'PetFrag', anchor: 'Pet:14'),
-      decoder: _json,
+      decoder: _tdJson,
     );
     // Drain first emission (immediate cache hit).
     await sub14.first.timeout(const Duration(seconds: 5));
@@ -600,9 +608,9 @@ void main() {
     //
     // For a white-box rebind test (with a known subId), use the Rust layer
     // tests in rust/shalom_runtime/tests/.
-    final sub15 = client.subscribeToFragment<JsonObject>(
+    final sub15 = client.subscribeToFragment<_TestData>(
       ref: ObservedRefInput(observableId: 'PetFrag', anchor: 'Pet:15'),
-      decoder: _json,
+      decoder: _tdJson,
     );
     final pet15 = _expectData(
       await sub15.first.timeout(const Duration(seconds: 5)),

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -1180,6 +1180,7 @@ impl ShalomRuntime {
             Ok(()) => state.has_emitted = true,
             Err(_) => {
                 if let Some(state) = manager.subscriptions.remove(&id) {
+                    state.cancel.notify_waiters();
                     self.subscription_tracker.lock().unsubscribe(state.keys);
                 }
             }

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -187,6 +187,22 @@ struct SubscriptionState {
     /// request driving it (see [`ShalomRuntime::execute_operation`]) can abort
     /// immediately instead of waiting on the next stream item.
     cancel: Arc<Notify>,
+    /// Whether this subscription has ever had a response pushed to it.
+    ///
+    /// Until the first emission, [`ShalomRuntime::notify_subscribers`] always
+    /// includes this subscription regardless of whether the triggering write
+    /// actually changed any of its watched keys. This guarantees a first
+    /// delivery for subscriptions created under [`ExecutionPolicy::NetworkFirst`]
+    /// (which, unlike `CacheFirst`, don't emit synchronously from the cache at
+    /// creation time): if the network response happens to normalize to data
+    /// identical to what's already cached, `changed` comes back empty and the
+    /// key-diff filter alone would skip the subscriber forever, leaving it
+    /// with no data and no error. After the first emission, only the normal
+    /// diff-based filtering applies.
+    ///
+    /// Reset to `false` by [`ShalomRuntime::rebind_subscription`]'s fast path
+    /// when the anchor changes, since the subscription hasn't delivered data
+    /// for the new anchor yet.
     has_emitted: bool,
 }
 
@@ -623,9 +639,7 @@ impl ShalomRuntime {
                 operation_id: Some(op_name),
             };
             let mut manager = self.subscriptions.lock();
-            if let Some(state) = manager.subscriptions.get_mut(&id) {
-                let _ = state.sender.send(Ok(response)).map(|_| state.has_emitted = true);
-            }
+            self.send_or_remove(&mut manager, id, Ok(response));
         }
 
         id
@@ -668,9 +682,7 @@ impl ShalomRuntime {
                 operation_id: Some(fragment.get_fragment_name().to_string()),
             };
             let mut manager = self.subscriptions.lock();
-            if let Some(state) = manager.subscriptions.get_mut(&sub_id) {
-                let _ = state.sender.send(Ok(response)).map(|_| state.has_emitted = true);
-            }
+            self.send_or_remove(&mut manager, sub_id, Ok(response));
         }
 
         Ok(sub_id)
@@ -728,7 +740,7 @@ impl ShalomRuntime {
             self.subscription_tracker.lock().subscribe(new_keys.clone());
 
             // 2. Swap the subscription state.
-            let sender = {
+            {
                 let mut manager = self.subscriptions.lock();
                 match manager.subscriptions.get_mut(&id) {
                     Some(state) => {
@@ -738,7 +750,6 @@ impl ShalomRuntime {
                         };
                         state.keys = new_keys;
                         state.has_emitted = false;
-                        state.sender.clone()
                     }
                     None => {
                         // Subscription was cancelled between the snapshot and now.
@@ -763,9 +774,7 @@ impl ShalomRuntime {
                     operation_id: Some(fragment.get_fragment_name().to_string()),
                 };
                 let mut manager = self.subscriptions.lock();
-                if let Some(state) = manager.subscriptions.get_mut(&id) {
-                    let _ = state.sender.send(Ok(response)).map(|_| state.has_emitted = true);
-                }
+                self.send_or_remove(&mut manager, id, Ok(response));
             }
 
             Ok(id)
@@ -901,9 +910,7 @@ impl ShalomRuntime {
     /// Push a subscription error to a subscription so the Dart side sees it.
     pub fn push_subscription_error(&self, id: SubscriptionId, err: SubscriptionError) {
         let mut manager = self.subscriptions.lock();
-        if let Some(state) = manager.subscriptions.get_mut(&id) {
-            let _ = state.sender.send(Err(err)).map(|_| state.has_emitted = true);
-        }
+        self.send_or_remove(&mut manager, id, Err(err));
     }
 
     // -----------------------------------------------------------------------
@@ -1154,6 +1161,31 @@ impl ShalomRuntime {
         id
     }
 
+    /// Send `msg` on subscription `id`'s channel and mark it as emitted.
+    ///
+    /// If the receiver has been dropped (send fails), the subscription is
+    /// removed from `manager` and its keys released from the tracker — a
+    /// dead subscription left behind here would otherwise pin its cache keys
+    /// forever, since nothing else would ever call `unsubscribe` for it.
+    fn send_or_remove(
+        &self,
+        manager: &mut SubscriptionManager,
+        id: SubscriptionId,
+        msg: Result<RuntimeResponse, SubscriptionError>,
+    ) {
+        let Some(state) = manager.subscriptions.get_mut(&id) else {
+            return;
+        };
+        match state.sender.send(msg) {
+            Ok(()) => state.has_emitted = true,
+            Err(_) => {
+                if let Some(state) = manager.subscriptions.remove(&id) {
+                    self.subscription_tracker.lock().unsubscribe(state.keys);
+                }
+            }
+        }
+    }
+
     /// The cancellation signal for a subscription, fired when it's unsubscribed.
     /// Used by [`Self::execute_operation`] to abort an in-flight network
     /// request promptly instead of waiting on the next stream item.
@@ -1172,6 +1204,9 @@ impl ShalomRuntime {
                 .subscriptions
                 .iter()
                 .filter(|(_, state)| {
+                    // `!state.has_emitted`: guarantee a first delivery even if this
+                    // particular write didn't touch any of the subscription's keys
+                    // (see the field doc on `SubscriptionState::has_emitted`).
                     !state.has_emitted
                         || state.keys.is_empty()
                         || state.keys.iter().any(|k| changed.contains(k))
@@ -1210,24 +1245,21 @@ impl ShalomRuntime {
                     old_keys = Some(state.keys.clone());
                     state.keys = new_refs.clone();
                     if let Some(response) = response {
-                        let _ = state
-                            .sender
-                            .send(Ok(response))
-                            .map(|_| state.has_emitted = true)
-                            .map_err(|_| {
+                        match state.sender.send(Ok(response)) {
+                            Ok(()) => state.has_emitted = true,
+                            Err(_) => {
                                 manager.subscriptions.remove(&id);
                                 removed = true;
-                            });
+                            }
+                        }
                     }
                 }
             }
 
             if let Some(old_keys) = old_keys {
                 let mut tracker = self.subscription_tracker.lock();
-                if removed {
-                    tracker.unsubscribe(old_keys);
-                } else {
-                    tracker.unsubscribe(old_keys);
+                tracker.unsubscribe(old_keys);
+                if !removed {
                     tracker.subscribe(new_refs);
                 }
             }

--- a/rust/shalom_runtime/src/runtime.rs
+++ b/rust/shalom_runtime/src/runtime.rs
@@ -187,6 +187,7 @@ struct SubscriptionState {
     /// request driving it (see [`ShalomRuntime::execute_operation`]) can abort
     /// immediately instead of waiting on the next stream item.
     cancel: Arc<Notify>,
+    has_emitted: bool,
 }
 
 #[derive(Clone)]
@@ -621,9 +622,9 @@ impl ShalomRuntime {
                 data: initial.data,
                 operation_id: Some(op_name),
             };
-            let manager = self.subscriptions.lock();
-            if let Some(state) = manager.subscriptions.get(&id) {
-                let _ = state.sender.send(Ok(response));
+            let mut manager = self.subscriptions.lock();
+            if let Some(state) = manager.subscriptions.get_mut(&id) {
+                let _ = state.sender.send(Ok(response)).map(|_| state.has_emitted = true);
             }
         }
 
@@ -666,9 +667,9 @@ impl ShalomRuntime {
                 data: result.data,
                 operation_id: Some(fragment.get_fragment_name().to_string()),
             };
-            let manager = self.subscriptions.lock();
-            if let Some(state) = manager.subscriptions.get(&sub_id) {
-                let _ = state.sender.send(Ok(response));
+            let mut manager = self.subscriptions.lock();
+            if let Some(state) = manager.subscriptions.get_mut(&sub_id) {
+                let _ = state.sender.send(Ok(response)).map(|_| state.has_emitted = true);
             }
         }
 
@@ -736,6 +737,7 @@ impl ShalomRuntime {
                             anchor: new_anchor.clone(),
                         };
                         state.keys = new_keys;
+                        state.has_emitted = false;
                         state.sender.clone()
                     }
                     None => {
@@ -760,7 +762,10 @@ impl ShalomRuntime {
                     data: result.data,
                     operation_id: Some(fragment.get_fragment_name().to_string()),
                 };
-                let _ = sender.send(Ok(response));
+                let mut manager = self.subscriptions.lock();
+                if let Some(state) = manager.subscriptions.get_mut(&id) {
+                    let _ = state.sender.send(Ok(response)).map(|_| state.has_emitted = true);
+                }
             }
 
             Ok(id)
@@ -895,9 +900,9 @@ impl ShalomRuntime {
 
     /// Push a subscription error to a subscription so the Dart side sees it.
     pub fn push_subscription_error(&self, id: SubscriptionId, err: SubscriptionError) {
-        let manager = self.subscriptions.lock();
-        if let Some(state) = manager.subscriptions.get(&id) {
-            let _ = state.sender.send(Err(err));
+        let mut manager = self.subscriptions.lock();
+        if let Some(state) = manager.subscriptions.get_mut(&id) {
+            let _ = state.sender.send(Err(err)).map(|_| state.has_emitted = true);
         }
     }
 
@@ -1141,6 +1146,7 @@ impl ShalomRuntime {
                 sender,
                 receiver: Some(receiver),
                 cancel: Arc::new(Notify::new()),
+                has_emitted: false,
             },
         );
         drop(manager);
@@ -1166,7 +1172,9 @@ impl ShalomRuntime {
                 .subscriptions
                 .iter()
                 .filter(|(_, state)| {
-                    state.keys.is_empty() || state.keys.iter().any(|k| changed.contains(k))
+                    !state.has_emitted
+                        || state.keys.is_empty()
+                        || state.keys.iter().any(|k| changed.contains(k))
                 })
                 .map(|(id, state)| (*id, state.target.clone(), state.variables.clone()))
                 .collect()
@@ -1201,12 +1209,15 @@ impl ShalomRuntime {
                 if let Some(state) = manager.subscriptions.get_mut(&id) {
                     old_keys = Some(state.keys.clone());
                     state.keys = new_refs.clone();
-                    if response
-                        .map(|response| state.sender.send(Ok(response)).is_err())
-                        .unwrap_or(false)
-                    {
-                        manager.subscriptions.remove(&id);
-                        removed = true;
+                    if let Some(response) = response {
+                        let _ = state
+                            .sender
+                            .send(Ok(response))
+                            .map(|_| state.has_emitted = true)
+                            .map_err(|_| {
+                                manager.subscriptions.remove(&id);
+                                removed = true;
+                            });
                     }
                 }
             }


### PR DESCRIPTION
I've added a simple flag `has_emitted` to subscription state, so if we got identical data in `networkFirst` mode we would emit those data to listeners at least once, so the UI could react to new data on refetch.

it fixes [this issue](https://github.com/nrbnlulu/shalom/issues/153)

## Summary by Sourcery

Track subscription emission state to ensure networkFirst refetches always deliver at least one response, even when data is unchanged.

Bug Fixes:
- Ensure subscriptions in networkFirst mode emit warm data at least once on refetch so UI can react to identical responses.

Enhancements:
- Track a per-subscription has_emitted flag to control when subscriptions should be re-executed and updated on successful or error deliveries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription listeners now receive their initial response even when a cache update does not change the watched data.
  - Rebinding a subscription correctly resets its notification state, ensuring the newly bound data is delivered.
  - Subscriptions with closed receivers are automatically cleaned up, preventing stale listeners from receiving further updates.
  - Initial responses, errors, and subsequent updates now follow consistent delivery and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->