### PR TITLE
relax already closed websocket streams (retry)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
 
             - name: Test
               run: |
-                  task test
+                  task test -- --no-fmt
 
             - name: Install typos
               if: runner.os == 'Linux'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,10 @@ jobs:
                   flutter packages get
 
             - name: Test
+              env:
+                  SHALOM_TEST_THREADS: ${{ runner.os == 'Windows' && '1' || '2' }}
               run: |
-                  task test -- --no-fmt
+                  task test
 
             - name: Install typos
               if: runner.os == 'Linux'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,6 +4,7 @@ version: "3"
 
 vars:
     GREETING: Hello, World!
+    TEST_THREADS: '{{default "2" .SHALOM_TEST_THREADS}}'
     DART_BIN:
         sh: |
             if command -v fvm > /dev/null 2>&1; then
@@ -50,8 +51,6 @@ tasks:
             - typos
 
     test:
-        env:
-            SHALOM_TEST_NO_FMT: '{{if contains "--no-fmt" .CLI_ARGS}}1{{else}}0{{end}}'
         cmds:
-            - cd rust && cargo test -- --test-threads=2
+            - cd rust && cargo test -- --test-threads={{.TEST_THREADS}}
             - cd dart/shalom && {{.DART_BIN}} test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,8 @@ tasks:
             - typos
 
     test:
+        env:
+            SHALOM_TEST_NO_FMT: '{{if contains "--no-fmt" .CLI_ARGS}}1{{else}}0{{end}}'
         cmds:
             - cd rust && cargo test -- --test-threads=2
             - cd dart/shalom && {{.DART_BIN}} test

--- a/dart/shalom/lib/src/transport/web_socket_transport.dart
+++ b/dart/shalom/lib/src/transport/web_socket_transport.dart
@@ -65,7 +65,12 @@ class WebSocketPackageTransport implements WebSocketTransport {
     // tear down the underlying socket too.
     controller.onCancel = () async {
       await subscription.cancel();
-      await socket.close();
+
+      try {
+        await socket.close();
+      } on ws.WebSocketConnectionClosed {
+        // The peer already closed the socket.
+      }
     };
 
     final sender = MessageSender((String message) async {

--- a/dart/shalom/lib/src/transport/web_socket_transport.dart
+++ b/dart/shalom/lib/src/transport/web_socket_transport.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert' show utf8;
+import 'dart:developer' show log;
 
 import 'package:web_socket/web_socket.dart' as ws;
 
@@ -70,6 +71,7 @@ class WebSocketPackageTransport implements WebSocketTransport {
         await socket.close();
       } on ws.WebSocketConnectionClosed {
         // The peer already closed the socket.
+        log('WebSocketPackageTransport: socket already closed by peer');
       }
     };
 

--- a/dart/shalom/test/runtime_test.dart
+++ b/dart/shalom/test/runtime_test.dart
@@ -334,7 +334,8 @@ void main() {
                 client
                     .request<_TestData>(
                       name: 'GetUserDetails',
-                      decoder: (d) => _TestData(_json(d)['user'] as JsonObject? ?? {}),
+                      decoder: (d) =>
+                          _TestData(_json(d)['user'] as JsonObject? ?? {}),
                     )
                     .first,
               );

--- a/rust/shalom_dart_codegen/tests/common/mod.rs
+++ b/rust/shalom_dart_codegen/tests/common/mod.rs
@@ -76,10 +76,6 @@ fn run_codegen(cwd: &Path, strict: bool) {
     .unwrap()
 }
 
-fn should_format_test_output() -> bool {
-    std::env::var("SHALOM_TEST_NO_FMT").as_deref() != Ok("1")
-}
-
 /// `flutter test` (unlike `dart test`) does not run the `native_toolchain_rust`
 /// build hook automatically, so the FFI lib never lands in `.dart_tool/lib/`.
 /// Build it ourselves and drop it where `test_env.dart`'s `_nativeLibPath()`
@@ -134,27 +130,25 @@ pub fn run_dart_tests_for_usecase(usecase: &str) {
 
     let dart_test_root = tests_path("dart_tests").join("..");
     let dart_parts: Vec<&str> = dart.split_whitespace().collect();
-    if should_format_test_output() {
-        let mut dart_fmt = if dart_parts.len() > 1 {
-            let mut cmd = std::process::Command::new(dart_parts[0]);
-            for part in &dart_parts[1..] {
-                cmd.arg(part);
-            }
-            cmd
-        } else {
-            std::process::Command::new(&dart)
-        };
-        let output = dart_fmt
-            .current_dir(&dart_test_root)
-            .arg("format")
-            .arg(format!("test/{usecase}"))
-            .output()
-            .unwrap();
-        info!(
-            "Running command: {dart_fmt:?} inside {dart_test_root:?} => {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    let mut dart_fmt = if dart_parts.len() > 1 {
+        let mut cmd = std::process::Command::new(dart_parts[0]);
+        for part in &dart_parts[1..] {
+            cmd.arg(part);
+        }
+        cmd
+    } else {
+        std::process::Command::new(&dart)
+    };
+    let output = dart_fmt
+        .current_dir(&dart_test_root)
+        .arg("format")
+        .arg(format!("test/{usecase}"))
+        .output()
+        .unwrap();
+    info!(
+        "Running command: {dart_fmt:?} inside {dart_test_root:?} => {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let mut dart_test = if dart_parts.len() > 1 {
         let mut cmd = std::process::Command::new(dart_parts[0]);
@@ -193,30 +187,28 @@ pub fn run_flutter_tests(usecase: &str) {
     FLUTTER_TESTS_CODEGEN.call_once(|| {
         ensure_native_lib_built(root_dir);
         run_codegen(root_dir, true);
-        if should_format_test_output() {
-            let dart = get_dart_command().unwrap_or_else(|e| panic!("⚠️  {e}. install dart"));
-            let dart_parts: Vec<&str> = dart.split_whitespace().collect();
-            let mut dart_fmt = if dart_parts.len() > 1 {
-                let mut cmd = std::process::Command::new(dart_parts[0]);
-                for part in &dart_parts[1..] {
-                    cmd.arg(part);
-                }
-                cmd
-            } else {
-                std::process::Command::new(&dart)
-            };
-            let output = dart_fmt
-                .current_dir(root_dir)
-                .arg("format")
-                .arg("./lib")
-                .arg("./test")
-                .output()
-                .unwrap();
-            info!(
-                "Running command: {dart_fmt:?} => {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
+        let dart = get_dart_command().unwrap_or_else(|e| panic!("⚠️  {e}. install dart"));
+        let dart_parts: Vec<&str> = dart.split_whitespace().collect();
+        let mut dart_fmt = if dart_parts.len() > 1 {
+            let mut cmd = std::process::Command::new(dart_parts[0]);
+            for part in &dart_parts[1..] {
+                cmd.arg(part);
+            }
+            cmd
+        } else {
+            std::process::Command::new(&dart)
+        };
+        let output = dart_fmt
+            .current_dir(root_dir)
+            .arg("format")
+            .arg("./lib")
+            .arg("./test")
+            .output()
+            .unwrap();
+        info!(
+            "Running command: {dart_fmt:?} => {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     });
 
     let flutter_cmd = get_flutter_command().unwrap();

--- a/rust/shalom_dart_codegen/tests/common/mod.rs
+++ b/rust/shalom_dart_codegen/tests/common/mod.rs
@@ -76,6 +76,10 @@ fn run_codegen(cwd: &Path, strict: bool) {
     .unwrap()
 }
 
+fn should_format_test_output() -> bool {
+    std::env::var("SHALOM_TEST_NO_FMT").as_deref() != Ok("1")
+}
+
 /// `flutter test` (unlike `dart test`) does not run the `native_toolchain_rust`
 /// build hook automatically, so the FFI lib never lands in `.dart_tool/lib/`.
 /// Build it ourselves and drop it where `test_env.dart`'s `_nativeLibPath()`
@@ -130,25 +134,27 @@ pub fn run_dart_tests_for_usecase(usecase: &str) {
 
     let dart_test_root = tests_path("dart_tests").join("..");
     let dart_parts: Vec<&str> = dart.split_whitespace().collect();
-    let mut dart_fmt = if dart_parts.len() > 1 {
-        let mut cmd = std::process::Command::new(dart_parts[0]);
-        for part in &dart_parts[1..] {
-            cmd.arg(part);
-        }
-        cmd
-    } else {
-        std::process::Command::new(&dart)
-    };
-    let output = dart_fmt
-        .current_dir(&dart_test_root)
-        .arg("format")
-        .arg(format!("test/{usecase}"))
-        .output()
-        .unwrap();
-    info!(
-        "Running command: {dart_fmt:?} inside {dart_test_root:?} => {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    if should_format_test_output() {
+        let mut dart_fmt = if dart_parts.len() > 1 {
+            let mut cmd = std::process::Command::new(dart_parts[0]);
+            for part in &dart_parts[1..] {
+                cmd.arg(part);
+            }
+            cmd
+        } else {
+            std::process::Command::new(&dart)
+        };
+        let output = dart_fmt
+            .current_dir(&dart_test_root)
+            .arg("format")
+            .arg(format!("test/{usecase}"))
+            .output()
+            .unwrap();
+        info!(
+            "Running command: {dart_fmt:?} inside {dart_test_root:?} => {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     let mut dart_test = if dart_parts.len() > 1 {
         let mut cmd = std::process::Command::new(dart_parts[0]);
@@ -182,38 +188,35 @@ pub fn run_flutter_tests(usecase: &str) {
         Err(e) => eprintln!("Error initializing logger: {e}"),
     }
     let tests_dir = tests_path("flutter_tests");
-    let dart = match get_dart_command() {
-        Ok(cmd) => cmd,
-        Err(e) => {
-            panic!("⚠️  {e}. install dart");
-        }
-    };
     let root_dir = &tests_dir.parent().unwrap();
 
-    let dart_parts: Vec<&str> = dart.split_whitespace().collect();
     FLUTTER_TESTS_CODEGEN.call_once(|| {
         ensure_native_lib_built(root_dir);
         run_codegen(root_dir, true);
-        let mut dart_fmt = if dart_parts.len() > 1 {
-            let mut cmd = std::process::Command::new(dart_parts[0]);
-            for part in &dart_parts[1..] {
-                cmd.arg(part);
-            }
-            cmd
-        } else {
-            std::process::Command::new(&dart)
-        };
-        let output = dart_fmt
-            .current_dir(root_dir)
-            .arg("format")
-            .arg("./lib")
-            .arg("./test")
-            .output()
-            .unwrap();
-        info!(
-            "Running command: {dart_fmt:?} => {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
+        if should_format_test_output() {
+            let dart = get_dart_command().unwrap_or_else(|e| panic!("⚠️  {e}. install dart"));
+            let dart_parts: Vec<&str> = dart.split_whitespace().collect();
+            let mut dart_fmt = if dart_parts.len() > 1 {
+                let mut cmd = std::process::Command::new(dart_parts[0]);
+                for part in &dart_parts[1..] {
+                    cmd.arg(part);
+                }
+                cmd
+            } else {
+                std::process::Command::new(&dart)
+            };
+            let output = dart_fmt
+                .current_dir(root_dir)
+                .arg("format")
+                .arg("./lib")
+                .arg("./test")
+                .output()
+                .unwrap();
+            info!(
+                "Running command: {dart_fmt:?} => {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     });
 
     let flutter_cmd = get_flutter_command().unwrap();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent errors when attempting to close a WebSocket that has already been closed by the peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cancellation when the remote peer has already closed the WebSocket, allowing cleanup to complete successfully.

* **Tests**
  * Reformatted a test callback for improved readability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->