### PR TITLE
Fix flatten fields on interfaces avoid mixing siblings

### DIFF
--- a/rust/shalom_core/src/operation/types.rs
+++ b/rust/shalom_core/src/operation/types.rs
@@ -392,12 +392,7 @@ impl ObjectLikeCommon {
             for (on_type, type_cond) in current_obj.type_cond_selections.iter() {
                 if is_type_matching(on_type) {
                     resolved_selections.extend(type_cond.selections.iter().cloned());
-                    recursive_inner(
-                        root_type_name,
-                        resolved_selections,
-                        type_cond,
-                        ctx,
-                    );
+                    recursive_inner(root_type_name, resolved_selections, type_cond, ctx);
                 }
             }
         }

--- a/rust/shalom_core/src/operation/types.rs
+++ b/rust/shalom_core/src/operation/types.rs
@@ -367,13 +367,19 @@ impl ObjectLikeCommon {
                     recursive_inner(root_type_name, resolved_selections, frag_root, ctx);
                 }
             }
-            // these should also be safe to expand here
-            // since this type implements them
+            // Expand inline fragments and type conditioned selections ONLY if they match
+            // this target type or if the target type implements the condition interface.
+            // Incompatible type conditions are skipped because the server won't return those fields
+            // for non-matching concrete types.
+            let is_type_matching = |on_type: &str| {
+                root_type_name == on_type
+                    || ctx
+                        .schema_ctx
+                        .is_type_same_or_implementing_interface(root_type_name, on_type)
+            };
+
             for (on_type, inline_frag) in current_obj.used_inline_frags.iter() {
-                if ctx
-                    .schema_ctx
-                    .is_type_same_or_implementing_interface(root_type_name, on_type)
-                {
+                if is_type_matching(on_type) {
                     resolved_selections.extend(inline_frag.common.selections.iter().cloned());
                     recursive_inner(
                         root_type_name,
@@ -383,10 +389,17 @@ impl ObjectLikeCommon {
                     );
                 }
             }
-            // type conditioned selections should not be expanded here since
-            // even if you selected a selections that applies to the root type but
-            // in a type condition, you won't get it in the graphql response if
-            // the resolved type is other than that type condition concrete.
+            for (on_type, type_cond) in current_obj.type_cond_selections.iter() {
+                if is_type_matching(on_type) {
+                    resolved_selections.extend(type_cond.selections.iter().cloned());
+                    recursive_inner(
+                        root_type_name,
+                        resolved_selections,
+                        type_cond,
+                        ctx,
+                    );
+                }
+            }
         }
 
         let mut selections = BTreeSet::new();

--- a/rust/shalom_core/src/operation/types.rs
+++ b/rust/shalom_core/src/operation/types.rs
@@ -378,8 +378,8 @@ impl ObjectLikeCommon {
                         .is_type_same_or_implementing_interface(root_type_name, on_type)
             };
 
-            for (on_type, inline_frag) in current_obj.used_inline_frags.iter() {
-                if is_type_matching(on_type) {
+            for inline_frag in current_obj.used_inline_frags.values() {
+                if is_type_matching(&inline_frag.common.schema_typename) {
                     resolved_selections.extend(inline_frag.common.selections.iter().cloned());
                     recursive_inner(
                         root_type_name,

--- a/rust/shalom_dart_codegen/src/lib.rs
+++ b/rust/shalom_dart_codegen/src/lib.rs
@@ -579,6 +579,17 @@ where
         },
     );
 
+    let ctx_clone4 = ctx.clone();
+    env.add_function(
+        "get_all_selections_that_apply_on_this_type_only",
+        move |obj_like: ViaDeserialize<ObjectLikeCommon>| -> minijinja::Value {
+            let selections = obj_like
+                .0
+                .get_all_selections_that_apply_on_this_type_only(&ctx_clone4);
+            minijinja::Value::from_serialize(&selections)
+        },
+    );
+
     let executable_ctx_clone3 = executable_ctx.clone();
     env.add_function(
         "object_like_needs_variables",

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -399,9 +399,9 @@ null
     }
 {% endmacro %}
 
-{% macro selection_object_definition(object, use_observe=true, implement_fragments=true) -%}
-    class {{ object.path_name }} {% if implement_fragments %}{{ implements_used_fragments(object.used_fragments) }}{% endif %}  {
-        {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_distinct(object), use_observe=use_observe) }}
+{% macro selection_object_definition(object, use_observe=true) -%}
+    class {{ object.path_name }} {{ implements_used_fragments(implementable_fragments(object.used_fragments, object.unwrapped_fragments) if use_observe else object.used_fragments) }}  {
+        {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_that_apply_on_this_type_only(object), use_observe=use_observe) }}
     }
 {% endmacro %}
 

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -399,8 +399,8 @@ null
     }
 {% endmacro %}
 
-{% macro selection_object_definition(object, use_observe=true) -%}
-    class {{ object.path_name }} {{ implements_used_fragments(implementable_fragments(object.used_fragments, object.unwrapped_fragments) if use_observe else object.used_fragments) }}  {
+{% macro selection_object_definition(object, use_observe=true, implement_fragments=true) -%}
+    class {{ object.path_name }} {% if implement_fragments %}{{ implements_used_fragments(object.used_fragments) }}{% endif %}  {
         {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_that_apply_on_this_type_only(object), use_observe=use_observe) }}
     }
 {% endmacro %}

--- a/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
+++ b/rust/shalom_dart_codegen/templates/selection_macros.dart.jinja
@@ -401,7 +401,7 @@ null
 
 {% macro selection_object_definition(object, use_observe=true) -%}
     class {{ object.path_name }} {{ implements_used_fragments(implementable_fragments(object.used_fragments, object.unwrapped_fragments) if use_observe else object.used_fragments) }}  {
-        {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_distinct(object), use_observe=use_observe) }}
+        {{ selection_object_impl(object.path_name, object, is_root_selection=false, full_name=object.path_name, shared_selections=get_all_selections_that_apply_on_this_type_only(object), use_observe=use_observe) }}
     }
 {% endmacro %}
 


### PR DESCRIPTION
this PR will check that the conditioned type selections and inline frag selections would match the target type and don't mix all the possible type sibling fields in the generated target concrete class.

fixes: https://github.com/nrbnlulu/shalom/issues/152

___

## Summary by Sourcery

Ensure selection flattening only includes fields applicable to the concrete target type, avoiding mixing fields from non-matching type conditions or interface siblings.

Bug Fixes:
- Skip incompatible inline fragment and type-conditioned selections when resolving object-like selections so only fields valid for the concrete type are included.
- Update Dart selection object generation to use only selections that apply to the concrete type, preventing sibling interface fields from being emitted.

Enhancements:
- Expose a new helper in Dart codegen to retrieve all selections that apply only to a specific type for use in templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of type-specific selections in generated Dart code.
  - Correctly includes selections from compatible inline fragments and type conditions.
  - Excludes selections with incompatible type conditions.
  - Supports recursive traversal of nested type-conditioned selections.
  - Improves generated selection implementations for types that match directly or through supported interfaces.
  - Helps ensure generated code includes only selections applicable to the current type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->